### PR TITLE
multi: attempt calculating next PoW target correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -2085,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",

--- a/app/main.rs
+++ b/app/main.rs
@@ -89,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
     let (sequence_stream, mempool, tx_cache) = {
         mempool::init_sync_mempool(
             &mut enforcer,
-            &rpc_client,
+            rpc_client.clone(),
             &cli.node_zmq_addr_sequence,
         )
         .await?

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 [dependencies]
 anyhow = "1.0.86"
 async-trait = "0.1.81"
-bip300301 ={ workspace = true, features = ["tracing"] }
+bip300301 = { workspace = true, features = ["tracing"] }
 bitcoin = { version = "0.32.2", features = ["serde"] }
 blake3 = "1.5.3"
 borsh = "1.5.1"
@@ -26,6 +26,7 @@ nonempty = "0.11.0"
 num-traits = "0.2.19"
 parking_lot = "0.12.3"
 serde = { version = "1.0.208", features = ["derive"] }
+serde_json = "1.0.140"
 thiserror = "1.0.63"
 tokio = "1.38.0"
 tracing = "0.1.40"

--- a/lib/mempool/mod.rs
+++ b/lib/mempool/mod.rs
@@ -1,6 +1,11 @@
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt::Debug,
+};
 
-use bip300301::client::{BlockTemplateTransaction, RawMempoolTxFees};
+use bip300301::client::{
+    BlockTemplateTransaction, GetBlockClient, RawMempoolTxFees,
+};
 use bitcoin::{BlockHash, Target, Transaction, Txid, Weight};
 use hashlink::{LinkedHashMap, LinkedHashSet};
 use imbl::{ordmap, OrdMap, OrdSet};
@@ -146,6 +151,10 @@ impl ByAncestorFeeRate {
 struct Chain {
     tip: BlockHash,
     blocks: imbl::HashMap<BlockHash, bip300301::client::Block<true>>,
+    block_heights: imbl::HashMap<u64, BlockHash>,
+
+    // Used for fetching blocks that aren't in our local cache
+    main_client: jsonrpsee::http_client::HttpClient,
 }
 
 impl Chain {
@@ -164,6 +173,33 @@ impl Chain {
                 None
             }
         })
+    }
+
+    /// Find a block by its height
+    /// Returns None if no block with the given height exists in the chain
+    pub async fn get_block_by_height(
+        &self,
+        height: u64,
+    ) -> Result<bip300301::client::Block<true>, jsonrpsee::core::client::Error>
+    {
+        if let Some(hash) = self.block_heights.get(&height) {
+            tracing::debug!(
+                "Found block at height {} in cache: {}",
+                height,
+                hash
+            );
+            return Ok(self.blocks[hash].clone());
+        }
+
+        tracing::debug!("Fetching block at height {} from main client", height);
+
+        let block_hash = self.main_client.get_block_hash(height).await?;
+        let block = self
+            .main_client
+            .get_block(block_hash, bip300301::client::U8Witness::<2>)
+            .await?;
+
+        Ok(block)
     }
 }
 
@@ -206,10 +242,15 @@ pub struct Mempool {
 }
 
 impl Mempool {
-    fn new(prev_blockhash: BlockHash) -> Self {
+    fn new(
+        prev_blockhash: BlockHash,
+        main_client: jsonrpsee::http_client::HttpClient,
+    ) -> Self {
         let chain = Chain {
             tip: prev_blockhash,
             blocks: imbl::HashMap::new(),
+            block_heights: imbl::HashMap::new(),
+            main_client,
         };
         Self {
             by_ancestor_fee_rate: ByAncestorFeeRate::default(),
@@ -223,9 +264,86 @@ impl Mempool {
         &self.chain.blocks[&self.chain.tip]
     }
 
-    pub fn next_target(&self) -> Target {
-        // FIXME: calculate this properly
-        self.chain.blocks[&self.chain.tip].compact_target.into()
+    pub async fn next_target(
+        &self,
+        params: &bitcoin::consensus::Params,
+    ) -> Target {
+        let last_block = &self.chain.blocks[&self.chain.tip];
+
+        // If there's no retargeting on the network, that's great
+        if params.no_pow_retargeting {
+            return last_block.compact_target.into();
+        }
+
+        // We need to determine if we're on the boundary of a difficulty period
+        // If not, just return the current target
+        if ((last_block.height as u64) + 1)
+            % params.difficulty_adjustment_interval()
+            != 0
+        {
+            return last_block.compact_target.into();
+        }
+
+        // Difficulty adjustment!
+        let last_block_header = bitcoin::block::Header {
+            version: last_block.version,
+            prev_blockhash: last_block.previousblockhash.unwrap(),
+            merkle_root: last_block.merkleroot,
+            time: last_block.time,
+            bits: last_block.compact_target,
+            nonce: last_block.nonce,
+        };
+
+        // Get the block from the beginning of this difficulty adjustment period
+        let boundary_height = last_block.height as u64
+            - params.difficulty_adjustment_interval()
+            // +1 because we want the block at the beginning of the period, not the 
+            // first block of the /previous/ period
+            + 1;
+
+        // First try to get the block from cache
+        let boundary = match self
+            .chain
+            .get_block_by_height(boundary_height)
+            .await
+        {
+            Ok(block) => block,
+            Err(err) => {
+                // If we couldn't fetch the boundary block, we have to fall back to the current target
+                tracing::warn!(
+                    error = ?err,
+                    "Unable to find block at height {} for difficulty adjustment, using current target",
+                    boundary_height
+                );
+                return last_block.compact_target.into();
+            }
+        };
+
+        let boundary_header = bitcoin::block::Header {
+            version: boundary.version,
+            prev_blockhash: boundary.previousblockhash.unwrap(),
+            merkle_root: boundary.merkleroot,
+            time: boundary.time,
+            bits: boundary.compact_target,
+            nonce: boundary.nonce,
+        };
+
+        let compact_target =
+            bitcoin::CompactTarget::from_header_difficulty_adjustment(
+                boundary_header,
+                last_block_header,
+                params,
+            );
+
+        tracing::debug!(
+            last_block_height = last_block.height,
+            last_block_difficulty_adjustment_height = boundary_height,
+            "determined next PoW target: {:x} -> {:x}",
+            last_block_header.bits.to_consensus(),
+            compact_target.to_consensus()
+        );
+
+        compact_target.into()
     }
 
     /// Insert a tx into the mempool
@@ -559,4 +677,13 @@ impl Mempool {
         res.reverse();
         Ok(res)
     }
+}
+
+#[jsonrpsee::proc_macros::rpc(client)]
+trait HashFetcher {
+    #[method(name = "getblockhash")]
+    async fn get_block_hash(
+        &self,
+        height: u64,
+    ) -> Result<bitcoin::BlockHash, jsonrpsee::core::Error>;
 }

--- a/lib/mempool/sync/task.rs
+++ b/lib/mempool/sync/task.rs
@@ -203,11 +203,22 @@ where
     let resp_block_parent = resp_block
         .previousblockhash
         .unwrap_or_else(BlockHash::all_zeros);
+
+    let block_hash = resp_block.hash;
+    let block_height = resp_block.height;
+
     inner
         .mempool
         .chain
         .blocks
-        .insert(resp_block.hash, resp_block.clone());
+        .insert(block_hash, resp_block.clone());
+
+    inner
+        .mempool
+        .chain
+        .block_heights
+        .insert(block_height.into(), block_hash);
+
     let Some(SequenceMessage::BlockHash(block_hash_msg)) =
         sync_state.seq_message_queue.front()
     else {


### PR DESCRIPTION
Use BDK code to try and calculate the next PoW target correctly in block
template construction.

Note that this is not working. Not clear why, but blocks are being
rejected by Bitcoin Core.
