### PR TITLE
fix: skip stale conflict txids in insert and add_conflicts

### DIFF
--- a/.github/workflows/check_rust.yml
+++ b/.github/workflows/check_rust.yml
@@ -11,6 +11,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: x86_64-unknown-linux-gnu
+
+      - run: cargo test
+
+
   check-rustfmt:
     name: Check Rustfmt
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "tokio",
  "tracing",
  "typewit",
+ "ulid",
  "zeromq",
 ]
 
@@ -2489,6 +2490,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.2",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,6 +2655,16 @@ name = "web-sys"
 version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -31,6 +31,7 @@ tokio = "1.38.0"
 tracing = "0.1.40"
 typewit = "1.11.0"
 zeromq = "0.4.1"
+ulid = "1.2.1"
 
 [lints]
 workspace = true

--- a/lib/mempool/mod.rs
+++ b/lib/mempool/mod.rs
@@ -213,7 +213,7 @@ impl FeeRate {
     /// `self` and `other` are not equal when comparing as quotients.
     /// If `self` and `other` are equal when comparing as quotients,
     /// orders by `vsize`.
-    /// ```
+    /// ```text
     /// (self.fee / self.vsize) < (other.fee / other.vsize) ==> self < other,
     /// (self.fee / self.vsize) > (other.fee / other.vsize) ==> self > other,
     /// (self.fee == other.fee /\ other.fee == other.vsize) <==> self == other,

--- a/lib/mempool/mod.rs
+++ b/lib/mempool/mod.rs
@@ -712,6 +712,11 @@ impl Mempool {
             },
         )?;
         for conflict_txid in conflicts_with {
+            // The conflicting tx may have already been removed from the
+            // mempool (e.g. confirmed in a block). Skip it.
+            if !self.txs.0.contains_key(&conflict_txid) {
+                continue;
+            }
             self.txs.descendants_mut(conflict_txid).try_for_each(
                 |descendant_info| {
                     let (_descendant_tx, descendant_info) = descendant_info?;
@@ -908,6 +913,9 @@ impl Mempool {
         conflicts: Conflicts,
     ) -> Result<(), MempoolUpdateError> {
         for (txid_lo, conflict_txids) in conflicts.iter() {
+            if !self.txs.0.contains_key(txid_lo) {
+                continue;
+            }
             let conflict_txids = OrdSet::from(conflict_txids);
             if conflict_txids.is_empty() {
                 break;
@@ -924,6 +932,9 @@ impl Mempool {
             )?;
         }
         for (txid_hi, conflict_txids) in conflicts.iter_inverted() {
+            if !self.txs.0.contains_key(&txid_hi) {
+                continue;
+            }
             let conflict_txids = OrdSet::from(conflict_txids);
             if conflict_txids.is_empty() {
                 break;
@@ -1111,5 +1122,75 @@ impl Mempool {
         }
         res.reverse();
         Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::{
+        Amount, Network, OutPoint, ScriptBuf, Sequence, TxIn, TxOut, Witness,
+        absolute::LockTime, hashes::Hash as _, transaction::Version,
+    };
+
+    fn make_tx(inputs: &[OutPoint], num_outputs: usize) -> Transaction {
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: inputs
+                .iter()
+                .map(|prev| TxIn {
+                    previous_output: *prev,
+                    sequence: Sequence::MAX,
+                    script_sig: ScriptBuf::new(),
+                    witness: Witness::new(),
+                })
+                .collect(),
+            output: (0..num_outputs)
+                .map(|i| TxOut {
+                    value: Amount::from_sat(1000 * (i as u64 + 1)),
+                    script_pubkey: ScriptBuf::new(),
+                })
+                .collect(),
+        }
+    }
+
+    fn test_mempool() -> Mempool {
+        Mempool::new(Network::Regtest, BlockHash::all_zeros())
+    }
+
+    /// Reproduces the prod crash: inserting a tx whose `conflicts_with`
+    /// references a txid not present in the mempool (e.g. already confirmed
+    /// in a block) must not panic or error.
+    #[test]
+    fn insert_with_nonexistent_conflict_succeeds() {
+        let mut mempool = test_mempool();
+
+        let tx = make_tx(&[OutPoint::new(Txid::all_zeros(), 0)], 1);
+        let weight = tx.weight();
+        let absent_txid = Txid::from_byte_array([0x42; 32]);
+
+        let result = mempool.insert(tx, 100, OrdSet::unit(absent_txid), weight);
+
+        assert!(result.is_ok(), "insert failed: {result:?}");
+    }
+
+    /// Same scenario through `add_conflicts`: conflict references a txid
+    /// that is no longer in the mempool.
+    #[test]
+    fn add_conflicts_with_nonexistent_txid_succeeds() {
+        let mut mempool = test_mempool();
+
+        let tx = make_tx(&[OutPoint::new(Txid::all_zeros(), 0)], 1);
+        let txid = tx.compute_txid();
+        let weight = tx.weight();
+        mempool.insert(tx, 100, OrdSet::new(), weight).unwrap();
+
+        let absent_txid = Txid::from_byte_array([0x42; 32]);
+        let mut conflicts = Conflicts::default();
+        conflicts.insert(txid, absent_txid);
+
+        let result = mempool.add_conflicts(conflicts);
+        assert!(result.is_ok(), "add_conflicts failed: {result:?}");
     }
 }

--- a/lib/mempool/sync/task.rs
+++ b/lib/mempool/sync/task.rs
@@ -15,7 +15,7 @@ use hashlink::LinkedHashSet;
 use imbl::HashSet;
 use thiserror::Error;
 use tokio::{spawn, sync::RwLock, task::JoinHandle};
-use tracing::instrument;
+use tracing::{Instrument as _, instrument};
 
 use super::{
     super::{Conflicts, Mempool},
@@ -124,8 +124,7 @@ async fn handle_seq_message(
             mempool_seq: _,
             zmq_seq: _,
         }) => {
-            // FIXME: remove
-            tracing::debug!("Added {txid} to req queue");
+            tracing::debug!("Added tx {txid} to req queue");
             sync_state
                 .request_queue
                 .push_back(RequestItem::Tx(txid, true));
@@ -624,24 +623,32 @@ where
             .await
             .ok_or(SyncTaskError::CombinedStreamEnded)?;
 
-        tracing::debug!(
-            "Received stream message: `{}`",
-            match msg {
-                CombinedStreamItem::ZmqSeq(_) => "sequence",
-                CombinedStreamItem::Response(_) => "response",
-                CombinedStreamItem::Shutdown => "shutdown",
-            }
+        let msg_kind = match &msg {
+            CombinedStreamItem::ZmqSeq(_) => "sequence",
+            CombinedStreamItem::Response(_) => "response",
+            CombinedStreamItem::Shutdown => "shutdown",
+        };
+
+        let span = tracing::debug_span!(
+            "handle_stream_msg",
+            sequence_id = ulid::Ulid::new().to_string(), // ULIDs are clickable, short and sorts naturally by time
         );
+
+        tracing::debug!(parent: &span, "Processing {msg_kind} stream message");
 
         match msg {
             CombinedStreamItem::ZmqSeq(seq_msg) => {
-                let () = handle_seq_message(&mut sync_state, seq_msg?).await;
+                handle_seq_message(&mut sync_state, seq_msg?)
+                    .instrument(span)
+                    .await;
             }
             CombinedStreamItem::Response(resp) => {
-                let () = handle_resp(&inner, &mut sync_state, resp?).await?;
+                handle_resp(&inner, &mut sync_state, resp?)
+                    .instrument(span)
+                    .await?;
             }
             CombinedStreamItem::Shutdown => {
-                tracing::info!("shutdown signal received, aborting");
+                tracing::info!(parent: &span, "shutdown signal received, aborting");
                 // This isn't really an error though...
                 return Err(SyncTaskError::Shutdown);
             }


### PR DESCRIPTION
`descendants_mut(conflict_txid)` crashes with `MissingDescendantError`
when a conflict txid is no longer in the mempool (e.g. already confirmed
in a block). Guard with `contains_key` before iterating descendants.

Observed in prod as a crash loop during sync task init, when the
enforcer reported conflicts referencing a recently-confirmed tx.

Also add more tracing IDs and spans