### PR TITLE
integration tests: add 'em

### DIFF
--- a/.github/workflows/check_rust.yml
+++ b/.github/workflows/check_rust.yml
@@ -84,3 +84,37 @@ jobs:
 
       - name: Check for unused dependencies
         run: cargo shear --deny-warnings
+
+  integration-tests:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: x86_64-unknown-linux-gnu
+
+      # Caches bitcoind across CI runs so we don't re-download it every time.
+      # Keyed on the script (which pins the version) and OS.
+      - name: Cache integration-test deps
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: .integration-deps
+          key: integration-deps-${{ runner.os }}-${{ hashFiles('scripts/setup_integration_tests.sh') }}
+
+      - name: Set up bitcoind and integrationtests.env
+        run: ./scripts/setup_integration_tests.sh
+
+      - name: Build integration_tests binary
+        run: cargo build --bin integration_tests
+
+      - name: Run integration tests
+        run: |
+          set -a
+          source ./integrationtests.env
+          set +a
+          cargo run --bin integration_tests -- --test-threads=1

--- a/.github/workflows/check_rust.yml
+++ b/.github/workflows/check_rust.yml
@@ -113,8 +113,19 @@ jobs:
         run: cargo build --bin integration_tests
 
       - name: Run integration tests
+        env:
+          CUSF_TEST_ARTIFACTS_DIR: ${{ runner.temp }}/test-artifacts
         run: |
           set -a
           source ./integrationtests.env
           set +a
           cargo run --bin integration_tests -- --test-threads=1
+
+      - name: Upload integration test logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-logs
+          path: ${{ runner.temp }}/test-artifacts/
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .envrc
 shell.nix
+integrationtests.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cusf-enforcer-mempool-integration-tests"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitcoin",
+ "bitcoin-jsonrpsee",
+ "clap",
+ "cusf-enforcer-mempool",
+ "futures",
+ "libtest-mimic",
+ "parking_lot",
+ "reserve-port",
+ "serde",
+ "serde_json",
+ "temp-dir",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +613,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "escape8259"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
 
 [[package]]
 name = "ext-trait"
@@ -1439,6 +1469,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libtest-mimic"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e6ba06f0ade6e504aff834d7c34298e5155c6baca353cc6a4aaff2f9fd7f33"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap",
+ "escape8259",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1522,15 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -1850,6 +1901,15 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "reserve-port"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
+dependencies = [
+ "thiserror 2.0.16",
+]
 
 [[package]]
 name = "ring"
@@ -2284,6 +2344,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "temp-dir"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,6 +2487,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -2530,10 +2597,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["app", "lib"]
+members = ["app", "integration_tests", "lib"]
 
 [workspace.package]
 authors = ["Ash Manning <ash@layertwolabs.com>"]

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,24 @@
+build *args='':
+    cargo build {{ args }}
+
+# Run linter
+clippy:
+    cargo clippy --all-targets -- --deny warnings
+
+# Format code
+fmt:
+    cargo fmt --all
+
+# Run the integration tests. Forwards extra args to libtest-mimic.
+# Examples:
+#   just test-it
+#   just test-it basic_sync
+#   just test-it --nocapture reorg_re_inserts_tx
+[doc('Run integration tests')]
+test-it *args='': 
+    #!/usr/bin/env bash
+    set -euo pipefail
+    set -a
+    source ./integrationtests.env
+    set +a
+    cargo run --bin integration_tests -- {{ args }}

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "cusf-enforcer-mempool-integration-tests"
+authors.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+base64 = "0.22"
+bitcoin = { workspace = true }
+bitcoin-jsonrpsee = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+cusf-enforcer-mempool = { path = "../lib" }
+futures = { workspace = true }
+parking_lot = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+# Integration-test-only dependencies (not used elsewhere in the workspace,
+# so kept out of `[workspace.dependencies]`).
+libtest-mimic = "0.8.1"
+reserve-port = "2.2.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+temp-dir = "0.1.13"
+
+[lints]
+workspace = true
+
+[lib]
+name = "cusf_enforcer_mempool_integration_tests"
+path = "lib.rs"
+test = false
+doctest = false
+
+[[bin]]
+name = "integration_tests"
+path = "main.rs"
+test = false

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -1,0 +1,10 @@
+pub mod mock_enforcer;
+pub mod setup;
+pub mod test_accept_tx_paths;
+pub mod test_block_connect_smoke;
+pub mod test_compose_drops_remove_mempool_txs;
+pub mod test_double_insert_after_reorg;
+pub mod test_enforcer_rejection_during_reorg;
+pub mod test_rbf_removed_for_absent_tx;
+pub mod test_reorg_re_inserts_tx;
+pub mod util;

--- a/integration_tests/main.rs
+++ b/integration_tests/main.rs
@@ -1,0 +1,228 @@
+use std::time::Duration;
+
+use clap::Parser;
+use cusf_enforcer_mempool_integration_tests::{
+    setup::{Directories, TestSetup},
+    test_accept_tx_paths, test_block_connect_smoke,
+    test_compose_drops_remove_mempool_txs, test_double_insert_after_reorg,
+    test_enforcer_rejection_during_reorg, test_rbf_removed_for_absent_tx,
+    test_reorg_re_inserts_tx,
+    util::{BinPaths, TestFailure, TestFailureCollector},
+};
+use libtest_mimic::{Arguments, Trial};
+use tokio_util::task::AbortOnDropHandle;
+use tracing_subscriber::{
+    filter as tracing_filter, layer::SubscriberExt, util::SubscriberInitExt,
+};
+
+const PER_TEST_TIMEOUT: Duration = Duration::from_secs(180);
+
+#[derive(Parser)]
+struct Cli {
+    #[command(flatten)]
+    test_args: Arguments,
+}
+
+/// Saturating predecessor of a log level — for setting a quieter default on
+/// noisy upstream crates while keeping `log_level` for the integration tests.
+fn saturating_pred_level(log_level: tracing::Level) -> tracing::Level {
+    match log_level {
+        tracing::Level::TRACE => tracing::Level::DEBUG,
+        tracing::Level::DEBUG => tracing::Level::INFO,
+        tracing::Level::INFO => tracing::Level::WARN,
+        tracing::Level::WARN => tracing::Level::ERROR,
+        tracing::Level::ERROR => tracing::Level::ERROR,
+    }
+}
+
+fn targets_directive_str<'a>(
+    targets: impl IntoIterator<Item = (&'a str, tracing::Level)>,
+) -> String {
+    targets
+        .into_iter()
+        .map(|(target, level)| {
+            let level = level.as_str().to_ascii_lowercase();
+            if target.is_empty() {
+                level
+            } else {
+                format!("{target}={level}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn set_tracing_subscriber(log_level: tracing::Level) -> anyhow::Result<()> {
+    let targets_filter = {
+        let defaults = targets_directive_str([
+            ("", saturating_pred_level(log_level)),
+            ("cusf_enforcer_mempool", log_level),
+            ("cusf_enforcer_mempool_integration_tests", log_level),
+        ]);
+        let directives =
+            match std::env::var(tracing_filter::EnvFilter::DEFAULT_ENV) {
+                Ok(env) => format!("{defaults},{env}"),
+                Err(std::env::VarError::NotPresent) => defaults,
+                Err(err) => return Err(err.into()),
+            };
+        tracing_filter::EnvFilter::builder().parse(directives)?
+    };
+    tracing_subscriber::registry()
+        .with(targets_filter)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .compact()
+                .with_target(false)
+                .with_writer(std::io::stderr),
+        )
+        .try_init()
+        .map_err(|err| {
+            anyhow::anyhow!("setting tracing subscriber failed: {err:#}")
+        })
+}
+
+/// Build a `libtest-mimic` Trial. Creates a per-test `Directories`, passes
+/// it to `f`, and on failure records the test name + bitcoind log dir in
+/// `collector` for the end-of-run summary.
+fn make_trial<F, Fut>(
+    name: &str,
+    bin_paths: BinPaths,
+    collector: TestFailureCollector,
+    f: F,
+) -> Trial
+where
+    F: FnOnce(BinPaths, Directories) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    let name = name.to_owned();
+    let span_name = name.clone();
+    Trial::test(name.clone(), move || {
+        let test_name = name.clone();
+        let span_name = span_name.clone();
+        let outcome = std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio rt");
+            rt.block_on(async move {
+                let span = tracing::info_span!("test", name = %span_name);
+                let _entered = span.enter();
+                let dirs = Directories::new()?;
+                let bitcoind_dir = dirs.bitcoind_dir.clone();
+                let handle =
+                    AbortOnDropHandle::new(tokio::spawn(f(bin_paths, dirs)));
+                let result = match tokio::time::timeout(
+                    PER_TEST_TIMEOUT,
+                    handle,
+                )
+                .await
+                {
+                    Ok(Ok(r)) => r,
+                    Ok(Err(join_err)) => Err(anyhow::Error::new(join_err)
+                        .context("test task failed")),
+                    Err(_) => Err(anyhow::anyhow!(
+                        "test timed out after {PER_TEST_TIMEOUT:?}"
+                    )),
+                };
+                if let Err(err) = &result {
+                    collector.add_failure(TestFailure {
+                        test_name: test_name.clone(),
+                        error: format!("{err:#}"),
+                        log_dir: Some(bitcoind_dir),
+                    });
+                }
+                result
+            })
+        })
+        .join()
+        .map_err(|_| libtest_mimic::Failed::from("test thread panicked"))?;
+        outcome.map_err(|e| libtest_mimic::Failed::from(format!("{e:#}")))
+    })
+}
+
+fn run() -> anyhow::Result<std::process::ExitCode> {
+    let cli = Cli::parse();
+    set_tracing_subscriber(tracing::Level::DEBUG)?;
+
+    let bin_paths = BinPaths::new();
+    bin_paths.bitcoind().map_err(|err| {
+        anyhow::anyhow!("{err}\n\nSet BITCOIND to a bitcoind binary.")
+    })?;
+
+    let collector = TestFailureCollector::new();
+
+    type TrialFut = futures::future::BoxFuture<'static, anyhow::Result<()>>;
+    type SetupFn = fn(TestSetup) -> TrialFut;
+    type BareFn = fn(BinPaths, Directories) -> TrialFut;
+
+    let setup_tests: &[(&str, SetupFn)] = &[
+        ("block_connect_smoke", |s| {
+            Box::pin(test_block_connect_smoke::test_block_connect_smoke(s))
+        }),
+        ("reorg_re_inserts_tx", |s| {
+            Box::pin(test_reorg_re_inserts_tx::test_reorg_re_inserts_tx(s))
+        }),
+        ("enforcer_rejection_during_reorg", |s| {
+            Box::pin(
+                test_enforcer_rejection_during_reorg::test_enforcer_rejection_during_reorg(s),
+            )
+        }),
+        ("rbf_removed_for_absent_tx", |s| {
+            Box::pin(
+                test_rbf_removed_for_absent_tx::test_rbf_removed_for_absent_tx(
+                    s,
+                ),
+            )
+        }),
+    ];
+
+    let bare_tests: &[(&str, BareFn)] = &[
+        ("accept_tx_paths", |bp, dirs| {
+            Box::pin(test_accept_tx_paths::test_accept_tx_paths(bp, dirs))
+        }),
+        ("double_insert_after_reorg", |bp, dirs| {
+            Box::pin(
+                test_double_insert_after_reorg::test_double_insert_after_reorg(
+                    bp, dirs,
+                ),
+            )
+        }),
+        ("compose_drops_remove_mempool_txs", |bp, dirs| {
+            Box::pin(
+                test_compose_drops_remove_mempool_txs::test_compose_drops_remove_mempool_txs(bp, dirs),
+            )
+        }),
+    ];
+
+    let mut trials = Vec::new();
+    for (name, f) in setup_tests {
+        let f = *f;
+        trials.push(make_trial(
+            name,
+            bin_paths.clone(),
+            collector.clone(),
+            move |bp, dirs| async move {
+                let setup = TestSetup::new(&bp, dirs).await?;
+                f(setup).await
+            },
+        ));
+    }
+    for (name, f) in bare_tests {
+        let f = *f;
+        trials.push(make_trial(name, bin_paths.clone(), collector.clone(), f));
+    }
+
+    let exit_code = libtest_mimic::run(&cli.test_args, trials).exit_code();
+    collector.display_all_failures();
+    Ok(exit_code)
+}
+
+fn main() -> std::process::ExitCode {
+    match run() {
+        Ok(code) => code,
+        Err(err) => {
+            eprintln!("error: {err:#}");
+            std::process::ExitCode::from(1)
+        }
+    }
+}

--- a/integration_tests/main.rs
+++ b/integration_tests/main.rs
@@ -107,7 +107,7 @@ where
             rt.block_on(async move {
                 let span = tracing::info_span!("test", name = %span_name);
                 let _entered = span.enter();
-                let dirs = Directories::new()?;
+                let dirs = Directories::new(&test_name)?;
                 let bitcoind_dir = dirs.bitcoind_dir.clone();
                 let handle =
                     AbortOnDropHandle::new(tokio::spawn(f(bin_paths, dirs)));

--- a/integration_tests/mock_enforcer.rs
+++ b/integration_tests/mock_enforcer.rs
@@ -1,0 +1,172 @@
+//! A simple, configurable mock [`CusfEnforcer`] for integration tests.
+//! Shared with the sync task via an internal `Arc<Mutex<_>>`, so tests can
+//! tweak policy from outside while the task is running.
+
+use std::{
+    borrow::Borrow,
+    collections::{HashMap, HashSet},
+    convert::Infallible,
+    future::Future,
+    sync::Arc,
+};
+
+use bitcoin::{BlockHash, Transaction, Txid};
+use cusf_enforcer_mempool::cusf_enforcer::{
+    ConnectBlockAction, CusfEnforcer, DisconnectBlockAction, TxAcceptAction,
+};
+use parking_lot::Mutex;
+
+#[derive(Clone, Debug)]
+pub enum MockCall {
+    SyncToTip(BlockHash),
+    ConnectBlock(BlockHash),
+    DisconnectBlock(BlockHash),
+    AcceptTx(Txid),
+}
+
+#[derive(Default)]
+struct MockEnforcerInner {
+    reject_txids: HashSet<Txid>,
+    reject_all: bool,
+    reject_blocks: HashSet<BlockHash>,
+    reject_all_blocks: bool,
+    remove_on_connect: HashMap<BlockHash, HashSet<Txid>>,
+    remove_on_disconnect: HashMap<BlockHash, HashSet<Txid>>,
+    always_remove_on_disconnect: HashSet<Txid>,
+    log: Vec<MockCall>,
+}
+
+#[derive(Clone, Default)]
+pub struct MockEnforcer {
+    inner: Arc<Mutex<MockEnforcerInner>>,
+}
+
+impl MockEnforcer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn reject_tx(&self, txid: Txid) {
+        self.inner.lock().reject_txids.insert(txid);
+    }
+
+    pub fn set_reject_all(&self, reject_all: bool) {
+        self.inner.lock().reject_all = reject_all;
+    }
+
+    pub fn set_reject_all_blocks(&self, reject_all: bool) {
+        self.inner.lock().reject_all_blocks = reject_all;
+    }
+
+    pub fn set_always_remove_on_disconnect(&self, txids: HashSet<Txid>) {
+        self.inner.lock().always_remove_on_disconnect = txids;
+    }
+
+    pub fn disconnect_block_calls(&self) -> usize {
+        self.inner
+            .lock()
+            .log
+            .iter()
+            .filter(|c| matches!(c, MockCall::DisconnectBlock(_)))
+            .count()
+    }
+
+    /// Txids that `accept_tx` has been invoked with, in call order.
+    pub fn accept_tx_calls(&self) -> Vec<Txid> {
+        self.inner
+            .lock()
+            .log
+            .iter()
+            .filter_map(|c| match c {
+                MockCall::AcceptTx(t) => Some(*t),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+impl CusfEnforcer for MockEnforcer {
+    type SyncError = Infallible;
+
+    fn sync_to_tip<Signal: Future<Output = ()> + Send>(
+        &mut self,
+        _shutdown_signal: Signal,
+        tip: BlockHash,
+    ) -> impl Future<Output = Result<(), Self::SyncError>> + Send {
+        let inner = self.inner.clone();
+        async move {
+            inner.lock().log.push(MockCall::SyncToTip(tip));
+            Ok(())
+        }
+    }
+
+    type ConnectBlockError = Infallible;
+
+    fn connect_block(
+        &mut self,
+        block: &bitcoin::Block,
+    ) -> impl Future<
+        Output = Result<ConnectBlockAction, Self::ConnectBlockError>,
+    > + Send {
+        let block_hash = block.block_hash();
+        let inner = self.inner.clone();
+        async move {
+            let mut inner = inner.lock();
+            inner.log.push(MockCall::ConnectBlock(block_hash));
+            if inner.reject_all_blocks
+                || inner.reject_blocks.contains(&block_hash)
+            {
+                return Ok(ConnectBlockAction::Reject);
+            }
+            let remove_mempool_txs = inner
+                .remove_on_connect
+                .remove(&block_hash)
+                .unwrap_or_default();
+            Ok(ConnectBlockAction::Accept { remove_mempool_txs })
+        }
+    }
+
+    type DisconnectBlockError = Infallible;
+
+    fn disconnect_block(
+        &mut self,
+        block_hash: BlockHash,
+    ) -> impl Future<
+        Output = Result<DisconnectBlockAction, Self::DisconnectBlockError>,
+    > + Send {
+        let inner = self.inner.clone();
+        async move {
+            let mut inner = inner.lock();
+            inner.log.push(MockCall::DisconnectBlock(block_hash));
+            let mut remove_mempool_txs = inner
+                .remove_on_disconnect
+                .remove(&block_hash)
+                .unwrap_or_default();
+            remove_mempool_txs
+                .extend(inner.always_remove_on_disconnect.iter().copied());
+            Ok(DisconnectBlockAction { remove_mempool_txs })
+        }
+    }
+
+    type AcceptTxError = Infallible;
+
+    fn accept_tx<TxRef>(
+        &mut self,
+        tx: &Transaction,
+        _tx_inputs: &HashMap<Txid, TxRef>,
+    ) -> Result<TxAcceptAction, Self::AcceptTxError>
+    where
+        TxRef: Borrow<Transaction>,
+    {
+        let txid = tx.compute_txid();
+        let mut inner = self.inner.lock();
+        inner.log.push(MockCall::AcceptTx(txid));
+        if inner.reject_all || inner.reject_txids.contains(&txid) {
+            return Ok(TxAcceptAction::Reject);
+        }
+        Ok(TxAcceptAction::Accept {
+            conflicts_with: HashSet::new(),
+            weight_tweak: 0,
+        })
+    }
+}

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -1,0 +1,368 @@
+//! Test fixtures: spawn bitcoind, set up a wallet, then (optionally) run
+//! `init_sync_mempool` + start a `MempoolSync` against a `MockEnforcer`.
+
+use std::{collections::HashSet, path::PathBuf, sync::Arc, time::Duration};
+
+use anyhow::Context;
+use bitcoin::{Address, BlockHash, Network, Txid};
+use cusf_enforcer_mempool::{
+    cusf_enforcer::CusfEnforcer,
+    mempool::{self, MempoolSync, SyncTaskError},
+};
+use parking_lot::Mutex;
+use reserve_port::ReservedPort;
+use temp_dir::TempDir;
+use tokio::time::sleep;
+
+use crate::{
+    mock_enforcer::MockEnforcer,
+    util::{
+        self, BinPaths, Bitcoind, RpcClient, create_wallet, get_new_address,
+        wait_for_bitcoind_ready,
+    },
+};
+
+/// Per-test directory layout: a leaked temp dir with a `bitcoind/` subdir
+/// (where the bitcoind process writes its data and `stdout.txt`/`stderr.txt`).
+/// Leaked so logs survive after the test ends — helpful for debugging and
+/// for the end-of-run failure summary.
+#[derive(Clone, Debug)]
+pub struct Directories {
+    pub base_dir: PathBuf,
+    pub bitcoind_dir: PathBuf,
+}
+
+impl Directories {
+    pub fn new() -> anyhow::Result<Self> {
+        let temp = TempDir::new().context("creating temp dir")?;
+        let base_dir = temp.path().to_path_buf();
+        let bitcoind_dir = base_dir.join("bitcoind");
+        std::fs::create_dir(&bitcoind_dir)?;
+        temp.leak();
+        Ok(Self {
+            base_dir,
+            bitcoind_dir,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct ReservedPorts {
+    pub bitcoind_listen: ReservedPort,
+    pub bitcoind_rpc: ReservedPort,
+    pub bitcoind_zmq_sequence: ReservedPort,
+}
+
+impl ReservedPorts {
+    pub fn new() -> Result<Self, reserve_port::Error> {
+        Ok(Self {
+            bitcoind_listen: ReservedPort::random()?,
+            bitcoind_rpc: ReservedPort::random()?,
+            bitcoind_zmq_sequence: ReservedPort::random()?,
+        })
+    }
+}
+
+/// Errors surfaced by the running `MempoolSync` task.
+#[derive(Clone, Debug, Default)]
+pub struct TaskErrors {
+    inner: Arc<Mutex<Vec<String>>>,
+}
+
+impl TaskErrors {
+    pub fn snapshot(&self) -> Vec<String> {
+        self.inner.lock().clone()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().is_empty()
+    }
+}
+
+/// Bitcoind spawned with a funded regtest wallet and 110 priming blocks.
+/// Tests that need to seed bitcoind state between bitcoind-spawn and
+/// init-sync construct this directly, do their seeding inline against
+/// `rpc_client`, and then call [`TestSetup::start`].
+pub struct RegtestNode {
+    pub bitcoind: Bitcoind,
+    /// JSON-RPC client scoped to `it-wallet`.
+    pub rpc_client: RpcClient,
+    pub mining_address: Address,
+    pub directories: Directories,
+    // Drop order: bitcoind process → ports.
+    _bitcoind_handle: util::AbortOnDrop<()>,
+    _reserved_ports: ReservedPorts,
+}
+
+impl RegtestNode {
+    pub const WALLET: &'static str = "it-wallet";
+
+    pub async fn new(
+        bin_paths: &BinPaths,
+        directories: Directories,
+    ) -> anyhow::Result<Self> {
+        let reserved_ports = ReservedPorts::new()?;
+        let bitcoind = Bitcoind {
+            path: bin_paths.bitcoind()?.to_path_buf(),
+            data_dir: directories.bitcoind_dir.clone(),
+            listen_port: reserved_ports.bitcoind_listen.port(),
+            rpc_port: reserved_ports.bitcoind_rpc.port(),
+            rpc_user: "regtest".to_owned(),
+            rpc_pass: "regtest".to_owned(),
+            zmq_sequence_port: reserved_ports.bitcoind_zmq_sequence.port(),
+        };
+        tracing::info!(
+            rpc_port = bitcoind.rpc_port,
+            zmq_port = bitcoind.zmq_sequence_port,
+            data_dir = %bitcoind.data_dir.display(),
+            "spawning bitcoind"
+        );
+        let bitcoind_handle = bitcoind.spawn().context("spawning bitcoind")?;
+
+        let rpc_client = {
+            let daemon_rpc = bitcoind.http_client(None)?;
+            wait_for_bitcoind_ready(&daemon_rpc).await?;
+            create_wallet(&daemon_rpc, Self::WALLET)
+                .await
+                .context("createwallet")?;
+
+            bitcoind.http_client(Some(Self::WALLET))?
+        };
+
+        let mining_address: Address = get_new_address(&rpc_client)
+            .await
+            .context("getnewaddress")?;
+
+        // 110 (not 101) so the wallet keeps several mature coinbases — a
+        // reorg that strips the latest coinbase otherwise hits "Insufficient
+        // funds" in tests that bump-fee or send another tx.
+        bitcoin_jsonrpsee::MainClient::generate_to_address(
+            &rpc_client,
+            110,
+            &mining_address.clone().into_unchecked(),
+        )
+        .await
+        .context("generatetoaddress 110")?;
+
+        Ok(Self {
+            bitcoind,
+            rpc_client,
+            mining_address,
+            directories,
+            _bitcoind_handle: bitcoind_handle,
+            _reserved_ports: reserved_ports,
+        })
+    }
+}
+
+/// Wire `init_sync_mempool` + `MempoolSync::new` against `enforcer`.
+/// Generic over any `CusfEnforcer + Clone + Send + Sync + 'static`.
+pub async fn start_mempool_sync<E>(
+    node: &RegtestNode,
+    mut enforcer: E,
+) -> anyhow::Result<(MempoolSync<E>, TaskErrors)>
+where
+    E: CusfEnforcer + Clone + Send + Sync + 'static,
+{
+    let (sequence_stream, mempool, tx_cache) = mempool::init_sync_mempool(
+        &mut enforcer,
+        Network::Regtest,
+        &node.rpc_client,
+        &node.bitcoind.zmq_addr(),
+        std::future::pending::<()>(),
+    )
+    .await
+    .context("init_sync_mempool")?;
+
+    let task_errors = TaskErrors::default();
+    let errors_for_handler = task_errors.clone();
+    let mempool_sync = MempoolSync::new(
+        enforcer,
+        mempool,
+        tx_cache,
+        node.rpc_client.clone(),
+        sequence_stream,
+        move |err: SyncTaskError<E>| async move {
+            let msg = format!("{err:#}");
+            tracing::error!(err = %msg, "MempoolSync task error");
+            errors_for_handler.inner.lock().push(msg);
+        },
+    );
+    Ok((mempool_sync, task_errors))
+}
+
+/// `RegtestNode` + a running `MempoolSync` over a shared `MockEnforcer`. The
+/// methods on `TestSetup` are limited to the non-trivial mempool-sync
+/// observations; everything bitcoind-related goes through
+/// `setup.node.rpc_client` (or the `util::*` RPC helpers for wallet RPCs
+/// not exposed by `MainClient`).
+pub struct TestSetup {
+    pub node: RegtestNode,
+    pub mempool_sync: MempoolSync<MockEnforcer>,
+    pub enforcer: MockEnforcer,
+    pub task_errors: TaskErrors,
+}
+
+impl TestSetup {
+    /// One-shot: spawn bitcoind, mine priming blocks, run init-sync, start
+    /// the task. For tests that need to seed bitcoind between spawn and
+    /// init-sync, build a [`RegtestNode`] directly and call
+    /// [`TestSetup::start`].
+    pub async fn new(
+        bin_paths: &BinPaths,
+        directories: Directories,
+    ) -> anyhow::Result<Self> {
+        Self::start(RegtestNode::new(bin_paths, directories).await?).await
+    }
+
+    /// Run `init_sync_mempool` + start the task on an existing `RegtestNode`.
+    pub async fn start(node: RegtestNode) -> anyhow::Result<Self> {
+        let enforcer = MockEnforcer::new();
+        let (mempool_sync, task_errors) =
+            start_mempool_sync(&node, enforcer.clone()).await?;
+        Ok(Self {
+            node,
+            mempool_sync,
+            enforcer,
+            task_errors,
+        })
+    }
+
+    /// Submit a tx and wait for it to appear in the local `MempoolSync`
+    /// view. The most-common composite operation.
+    pub async fn submit_and_wait(
+        &self,
+        amount_sat: u64,
+    ) -> anyhow::Result<Txid> {
+        let txid = util::submit_tx(&self.node.rpc_client, amount_sat).await?;
+        self.wait_for_local_mempool(
+            Duration::from_secs(5),
+            |t| t.contains(&txid),
+            "submitted tx",
+        )
+        .await?;
+        Ok(txid)
+    }
+
+    pub async fn local_mempool_txids(&self) -> HashSet<Txid> {
+        local_mempool_txids(&self.mempool_sync).await
+    }
+
+    pub async fn wait_for_local_mempool<F>(
+        &self,
+        timeout_duration: Duration,
+        predicate: F,
+        label: &str,
+    ) -> anyhow::Result<()>
+    where
+        F: FnMut(&HashSet<Txid>) -> bool,
+    {
+        wait_for_local_mempool(
+            &self.mempool_sync,
+            &self.task_errors,
+            timeout_duration,
+            predicate,
+            label,
+        )
+        .await
+    }
+
+    pub async fn wait_for_local_tip(
+        &self,
+        expected: BlockHash,
+        timeout_duration: Duration,
+    ) -> anyhow::Result<()> {
+        wait_for_local_tip(
+            &self.mempool_sync,
+            &self.task_errors,
+            expected,
+            timeout_duration,
+        )
+        .await
+    }
+}
+
+// --- Free fns over `&MempoolSync<E>` (used by tests with non-Mock enforcers). ---
+
+pub async fn local_mempool_txids<E>(sync: &MempoolSync<E>) -> HashSet<Txid>
+where
+    E: CusfEnforcer + Send + Sync + 'static,
+{
+    sync.with(|mempool, _| {
+        Box::pin(async move {
+            mempool
+                .propose_txs(None)
+                .map(|v| v.into_iter().map(|t| t.txid).collect())
+                .unwrap_or_default()
+        })
+    })
+    .await
+    .unwrap_or_default()
+}
+
+pub async fn wait_for_local_mempool<E, F>(
+    sync: &MempoolSync<E>,
+    task_errors: &TaskErrors,
+    timeout_duration: Duration,
+    mut predicate: F,
+    label: &str,
+) -> anyhow::Result<()>
+where
+    E: CusfEnforcer + Send + Sync + 'static,
+    F: FnMut(&HashSet<Txid>) -> bool,
+{
+    let deadline = tokio::time::Instant::now() + timeout_duration;
+    let mut last = HashSet::new();
+    while tokio::time::Instant::now() < deadline {
+        last = local_mempool_txids(sync).await;
+        if predicate(&last) {
+            return Ok(());
+        }
+        if !task_errors.is_empty() {
+            anyhow::bail!(
+                "MempoolSync task surfaced errors while waiting for `{label}`: {:?}",
+                task_errors.snapshot()
+            );
+        }
+        sleep(Duration::from_millis(75)).await;
+    }
+    anyhow::bail!(
+        "timed out waiting for `{label}` after {timeout_duration:?}; \
+         last local mempool: {last:?}; task errors: {:?}",
+        task_errors.snapshot()
+    );
+}
+
+pub async fn wait_for_local_tip<E>(
+    sync: &MempoolSync<E>,
+    task_errors: &TaskErrors,
+    expected: BlockHash,
+    timeout_duration: Duration,
+) -> anyhow::Result<()>
+where
+    E: CusfEnforcer + Send + Sync + 'static,
+{
+    let deadline = tokio::time::Instant::now() + timeout_duration;
+    loop {
+        let current = sync
+            .with(|mempool, _| Box::pin(async move { mempool.tip().hash }))
+            .await;
+        if current == Some(expected) {
+            return Ok(());
+        }
+        if !task_errors.is_empty() {
+            anyhow::bail!(
+                "MempoolSync task surfaced errors while waiting for tip {expected}: {:?}",
+                task_errors.snapshot()
+            );
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for local tip = {expected} after \
+                 {timeout_duration:?}; saw {current:?}; task errors: {:?}",
+                task_errors.snapshot()
+            );
+        }
+        sleep(Duration::from_millis(75)).await;
+    }
+}

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -22,10 +22,14 @@ use crate::{
     },
 };
 
-/// Per-test directory layout: a leaked temp dir with a `bitcoind/` subdir
-/// (where the bitcoind process writes its data and `stdout.txt`/`stderr.txt`).
-/// Leaked so logs survive after the test ends — helpful for debugging and
-/// for the end-of-run failure summary.
+/// Per-test directory layout: `<base>/bitcoind/` with the bitcoind process's
+/// data dir, `stdout.txt`, and `stderr.txt`.
+///
+/// Path selection:
+/// - If `CUSF_TEST_ARTIFACTS_DIR` is set, place per-test directories under
+///   `$CUSF_TEST_ARTIFACTS_DIR/<test_name>/`. CI uses this to collect logs
+///   as build artifacts.
+/// - Otherwise use a tempdir under the system temp.
 #[derive(Clone, Debug)]
 pub struct Directories {
     pub base_dir: PathBuf,
@@ -33,12 +37,24 @@ pub struct Directories {
 }
 
 impl Directories {
-    pub fn new() -> anyhow::Result<Self> {
-        let temp = TempDir::new().context("creating temp dir")?;
-        let base_dir = temp.path().to_path_buf();
+    pub fn new(test_name: &str) -> anyhow::Result<Self> {
+        let base_dir = match std::env::var("CUSF_TEST_ARTIFACTS_DIR") {
+            Ok(root) => {
+                let dir = PathBuf::from(root).join(test_name);
+                std::fs::create_dir_all(&dir).with_context(|| {
+                    format!("creating artifact dir at {}", dir.display())
+                })?;
+                dir
+            }
+            Err(_) => {
+                let temp = TempDir::new().context("creating temp dir")?;
+                let path = temp.path().to_path_buf();
+                temp.leak();
+                path
+            }
+        };
         let bitcoind_dir = base_dir.join("bitcoind");
-        std::fs::create_dir(&bitcoind_dir)?;
-        temp.leak();
+        std::fs::create_dir_all(&bitcoind_dir)?;
         Ok(Self {
             base_dir,
             bitcoind_dir,

--- a/integration_tests/test_accept_tx_paths.rs
+++ b/integration_tests/test_accept_tx_paths.rs
@@ -1,0 +1,53 @@
+//! `accept_tx` runs over both the initial-sync filter pass (for pre-existing
+//! mempool txs) and the running task path (for txs added afterwards).
+
+use std::time::Duration;
+
+use crate::{
+    setup::{Directories, RegtestNode, TestSetup},
+    util::{BinPaths, submit_tx, wait_for_mempool_pred},
+};
+
+pub async fn test_accept_tx_paths(
+    bin_paths: BinPaths,
+    directories: Directories,
+) -> anyhow::Result<()> {
+    let node = RegtestNode::new(&bin_paths, directories).await?;
+
+    // Seed a tx BEFORE init_sync runs; the initial mempool-filter pass must
+    // route it through accept_tx.
+    let pre_sync_tx = submit_tx(&node.rpc_client, 50_000).await?;
+    wait_for_mempool_pred(
+        &node.rpc_client,
+        Duration::from_secs(5),
+        |t| t.contains(&pre_sync_tx),
+        "seed tx in bitcoind mempool",
+    )
+    .await?;
+
+    let setup = TestSetup::start(node).await?;
+    setup
+        .wait_for_local_mempool(
+            Duration::from_secs(5),
+            |t| t.contains(&pre_sync_tx),
+            "pre-sync tx in local mempool after init_sync",
+        )
+        .await?;
+
+    let post_sync_tx = setup.submit_and_wait(50_000).await?;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let calls = setup.enforcer.accept_tx_calls();
+        if calls.contains(&pre_sync_tx) && calls.contains(&post_sync_tx) {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "expected accept_tx for both {pre_sync_tx} (pre-sync) and \
+                 {post_sync_tx} (post-sync); saw {calls:?}"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}

--- a/integration_tests/test_block_connect_smoke.rs
+++ b/integration_tests/test_block_connect_smoke.rs
@@ -1,0 +1,41 @@
+//! Smoke test for the block-connect path: mining advances the local tip,
+//! confirmed txs are dropped from the local mempool view, and the sync task
+//! keeps processing afterwards. Doesn't gate any specific PR17 finding;
+//! catches gross regressions in `connect_block`.
+
+use std::time::Duration;
+
+use bitcoin_jsonrpsee::{MainClient as _, client::GetBlockClient as _};
+
+use crate::setup::TestSetup;
+
+pub async fn test_block_connect_smoke(setup: TestSetup) -> anyhow::Result<()> {
+    let tx = setup.submit_and_wait(50_000).await?;
+
+    let block_hash = *setup
+        .node
+        .rpc_client
+        .generate_to_address(
+            1,
+            &setup.node.mining_address.clone().into_unchecked(),
+        )
+        .await?
+        .last()
+        .unwrap();
+    let block = setup
+        .node
+        .rpc_client
+        .get_block(block_hash, bitcoin_jsonrpsee::client::U8Witness::<2>)
+        .await?;
+    anyhow::ensure!(
+        block.tx.iter().any(|t| t.txid == tx),
+        "expected {tx} in block {block_hash}"
+    );
+    setup
+        .wait_for_local_tip(block_hash, Duration::from_secs(5))
+        .await?;
+
+    let _followup = setup.submit_and_wait(40_000).await?;
+    anyhow::ensure!(!setup.local_mempool_txids().await.contains(&tx));
+    Ok(())
+}

--- a/integration_tests/test_compose_drops_remove_mempool_txs.rs
+++ b/integration_tests/test_compose_drops_remove_mempool_txs.rs
@@ -1,0 +1,78 @@
+//! Composing enforcers with mixed-results must propagate the
+//! rolled-back side's `remove_mempool_txs`.
+
+use std::{collections::HashSet, time::Duration};
+
+use cusf_enforcer_mempool::cusf_enforcer::Compose;
+use tokio::time::sleep;
+
+use crate::{
+    mock_enforcer::MockEnforcer,
+    setup::{
+        Directories, RegtestNode, local_mempool_txids, start_mempool_sync,
+        wait_for_local_mempool,
+    },
+    util::{
+        BinPaths, generate_block, get_new_address, submit_tx,
+        wait_for_mempool_pred,
+    },
+};
+
+pub async fn test_compose_drops_remove_mempool_txs(
+    bin_paths: BinPaths,
+    directories: Directories,
+) -> anyhow::Result<()> {
+    let node = RegtestNode::new(&bin_paths, directories).await?;
+
+    // Subject tx: both Compose halves default-accept it into mempool.
+    let tx = submit_tx(&node.rpc_client, 50_000).await?;
+    wait_for_mempool_pred(
+        &node.rpc_client,
+        Duration::from_secs(5),
+        |t| t.contains(&tx),
+        "subject tx in bitcoind mempool",
+    )
+    .await?;
+
+    let enforcer_a = MockEnforcer::new();
+    let enforcer_b = MockEnforcer::new();
+    let compose = Compose::new(enforcer_a.clone(), enforcer_b.clone());
+    let (mempool_sync, task_errors) =
+        start_mempool_sync(&node, compose).await?;
+
+    wait_for_local_mempool(
+        &mempool_sync,
+        &task_errors,
+        Duration::from_secs(5),
+        |t| t.contains(&tx),
+        "subject tx in local mempool",
+    )
+    .await?;
+
+    // Trigger the mixed-result branch: A accepts (and on disconnect demands
+    // the subject tx be removed), B rejects every block.
+    enforcer_a.set_always_remove_on_disconnect(HashSet::from([tx]));
+    enforcer_b.set_reject_all_blocks(true);
+
+    let dest = get_new_address(&node.rpc_client).await?;
+    generate_block(&node.rpc_client, &dest, &[]).await?;
+    sleep(Duration::from_secs(2)).await;
+
+    anyhow::ensure!(
+        task_errors.is_empty(),
+        "task errors: {:?}",
+        task_errors.snapshot()
+    );
+    anyhow::ensure!(
+        enforcer_a.disconnect_block_calls() >= 1,
+        "expected A.disconnect_block to fire (Compose's rollback path)"
+    );
+
+    let local = local_mempool_txids(&mempool_sync).await;
+    anyhow::ensure!(
+        !local.contains(&tx),
+        "Compose's mixed-result branch dropped A.disconnect_block's \
+         remove_mempool_txs: subject tx still in local mempool: {local:?}"
+    );
+    Ok(())
+}

--- a/integration_tests/test_double_insert_after_reorg.rs
+++ b/integration_tests/test_double_insert_after_reorg.rs
@@ -1,0 +1,72 @@
+//! When `handle_disconnected_block` defers a tx via `InsertTx` (because its
+//! parent isn't in `tx_cache`) AND bitcoind's reorg-recovery re-broadcasts
+//! the same tx via ZMQ `Added`, `mempool.insert` is called twice and the
+//! second call returns `TxAlreadyExists`.
+//!
+//! To force the deferred path: confirm the tx into a block BEFORE
+//! `init_sync_mempool` runs, so the sync task starts with an empty
+//! `tx_cache` and the disconnect handler can't find the tx's coinbase
+//! parent.
+
+use std::time::Duration;
+
+use bitcoin_jsonrpsee::MainClient as _;
+
+use crate::{
+    setup::{Directories, RegtestNode, TestSetup},
+    util::{BinPaths, submit_tx, wait_for_mempool_pred},
+};
+
+pub async fn test_double_insert_after_reorg(
+    bin_paths: BinPaths,
+    directories: Directories,
+) -> anyhow::Result<()> {
+    let node = RegtestNode::new(&bin_paths, directories).await?;
+
+    let tx = submit_tx(&node.rpc_client, 50_000).await?;
+    wait_for_mempool_pred(
+        &node.rpc_client,
+        Duration::from_secs(5),
+        |t| t.contains(&tx),
+        "seed tx in bitcoind mempool",
+    )
+    .await?;
+    node.rpc_client
+        .generate_to_address(1, &node.mining_address.clone().into_unchecked())
+        .await?;
+
+    let setup = TestSetup::start(node).await?;
+    let tip_with_tx = setup.node.rpc_client.getbestblockhash().await?;
+    setup.node.rpc_client.invalidate_block(tip_with_tx).await?;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    let mut errors = Vec::<String>::new();
+    while tokio::time::Instant::now() < deadline {
+        errors = setup.task_errors.snapshot();
+        if !errors.is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    if errors
+        .iter()
+        .any(|e| e.contains("already exists in mempool"))
+    {
+        anyhow::bail!(
+            "MempoolSync task aborted with TxAlreadyExists: {errors:?}"
+        );
+    }
+    anyhow::ensure!(
+        errors.is_empty(),
+        "MempoolSync task surfaced unexpected errors: {errors:?}"
+    );
+    setup
+        .wait_for_local_mempool(
+            Duration::from_secs(5),
+            |t| t.contains(&tx),
+            "tx in local mempool after deferred-reorg recovery",
+        )
+        .await?;
+    Ok(())
+}

--- a/integration_tests/test_enforcer_rejection_during_reorg.rs
+++ b/integration_tests/test_enforcer_rejection_during_reorg.rs
@@ -1,0 +1,94 @@
+//! Asserts two related behaviors:
+//!
+//! 1. When a reorg disconnects a block and the enforcer rejects a
+//!    re-inserted block tx, the sync task must stay healthy.
+//! 2. The enforcer rejection leaves bitcoind with the tx (low priority)
+//!    but us without it. After RBF emits a real `Removed(tx)`, a fresh
+//!    probe must STILL propagate, i.e. `Removed` for an absent tx must
+//!    not stall the queue.
+
+use std::time::Duration;
+
+use bitcoin_jsonrpsee::{MainClient as _, client::GetBlockClient as _};
+
+use crate::{
+    setup::TestSetup,
+    util::{bump_fee, wait_for_mempool_pred},
+};
+
+pub async fn test_enforcer_rejection_during_reorg(
+    setup: TestSetup,
+) -> anyhow::Result<()> {
+    let tx = setup.submit_and_wait(50_000).await?;
+
+    let pre_tip = setup.node.rpc_client.getbestblockhash().await?;
+    let b1 = setup
+        .node
+        .rpc_client
+        .generate_to_address(
+            1,
+            &setup.node.mining_address.clone().into_unchecked(),
+        )
+        .await?[0];
+    anyhow::ensure!(
+        setup
+            .node
+            .rpc_client
+            .get_block(b1, bitcoin_jsonrpsee::client::U8Witness::<2>)
+            .await?
+            .tx
+            .iter()
+            .any(|t| t.txid == tx),
+        "expected B1 to confirm {tx}"
+    );
+    setup.wait_for_local_tip(b1, Duration::from_secs(5)).await?;
+
+    // Reject the tx. The disconnect-recovery path is what calls
+    // `accept_tx(tx)` next.
+    setup.enforcer.reject_tx(tx);
+    setup.node.rpc_client.invalidate_block(b1).await?;
+
+    wait_for_mempool_pred(
+        &setup.node.rpc_client,
+        Duration::from_secs(10),
+        |t| t.contains(&tx),
+        "tx re-broadcast into bitcoind mempool",
+    )
+    .await?;
+    setup
+        .wait_for_local_tip(pre_tip, Duration::from_secs(10))
+        .await?;
+    anyhow::ensure!(
+        !setup.local_mempool_txids().await.contains(&tx),
+        "tx should be absent from local mempool after rejection"
+    );
+
+    // Assertion 1: a fresh tx still propagates immediately after the
+    // rejection.
+    let _probe1 = setup.submit_and_wait(40_000).await?;
+
+    // Wait for RejectTx to fire (the `prioritisetransaction` RPC) before
+    // bumping, otherwise bumpfee may compute the new fee against an
+    // un-prioritised modified fee.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let tx_replacement = bump_fee(&setup.node.rpc_client, tx).await?;
+    wait_for_mempool_pred(
+        &setup.node.rpc_client,
+        Duration::from_secs(10),
+        |t| t.contains(&tx_replacement) && !t.contains(&tx),
+        "replacement in bitcoind mempool (REPLACED)",
+    )
+    .await?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Assertion 2: a fresh tx still propagates after `Removed(tx)` for our
+    // absent subject tx.
+    let _probe2 = setup.submit_and_wait(30_000).await?;
+
+    anyhow::ensure!(
+        setup.task_errors.is_empty(),
+        "MempoolSync task surfaced errors: {:?}",
+        setup.task_errors.snapshot()
+    );
+    Ok(())
+}

--- a/integration_tests/test_rbf_removed_for_absent_tx.rs
+++ b/integration_tests/test_rbf_removed_for_absent_tx.rs
@@ -1,0 +1,65 @@
+//! A ZMQ `Removed` event for a tx that's not in our local mempool must NOT
+//! stall the action queue.
+
+use std::time::Duration;
+
+use crate::{
+    setup::TestSetup,
+    util::{bump_fee, submit_tx, wait_for_mempool_pred},
+};
+
+pub async fn test_rbf_removed_for_absent_tx(
+    setup: TestSetup,
+) -> anyhow::Result<()> {
+    // Enforcer rejects everything; the tx lands in bitcoind's mempool but
+    // not ours.
+    setup.enforcer.set_reject_all(true);
+
+    let tx_rejected = submit_tx(&setup.node.rpc_client, 50_000).await?;
+    wait_for_mempool_pred(
+        &setup.node.rpc_client,
+        Duration::from_secs(5),
+        |t| t.contains(&tx_rejected),
+        "rejected tx in bitcoind mempool",
+    )
+    .await?;
+
+    // Wait until the task has consulted the enforcer (so RejectTx is queued
+    // before we bump the fee).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while !setup.enforcer.accept_tx_calls().contains(&tx_rejected) {
+        anyhow::ensure!(
+            tokio::time::Instant::now() < deadline,
+            "sync task never asked enforcer about {tx_rejected}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    anyhow::ensure!(
+        !setup.local_mempool_txids().await.contains(&tx_rejected),
+        "rejected tx should be absent from local mempool"
+    );
+
+    // RBF the rejected tx → bitcoind emits `Removed(tx_rejected)` (REPLACED)
+    // for a tx our local mempool doesn't contain. Action queue should stall
+    // on Pending.
+    let tx_replacement = bump_fee(&setup.node.rpc_client, tx_rejected).await?;
+    wait_for_mempool_pred(
+        &setup.node.rpc_client,
+        Duration::from_secs(10),
+        |t| t.contains(&tx_replacement) && !t.contains(&tx_rejected),
+        "replacement in bitcoind mempool",
+    )
+    .await?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Flip the enforcer back to accepting and verify a fresh tx propagates.
+    setup.enforcer.set_reject_all(false);
+    let _probe = setup.submit_and_wait(40_000).await?;
+
+    anyhow::ensure!(
+        setup.task_errors.is_empty(),
+        "task errors: {:?}",
+        setup.task_errors.snapshot()
+    );
+    Ok(())
+}

--- a/integration_tests/test_reorg_re_inserts_tx.rs
+++ b/integration_tests/test_reorg_re_inserts_tx.rs
@@ -1,0 +1,66 @@
+//! A reorg restores a confirmed tx to the local mempool, and the sync task
+//! stays healthy.
+
+use std::time::Duration;
+
+use bitcoin_jsonrpsee::{MainClient as _, client::GetBlockClient as _};
+
+use crate::{setup::TestSetup, util::wait_for_mempool_pred};
+
+pub async fn test_reorg_re_inserts_tx(setup: TestSetup) -> anyhow::Result<()> {
+    let tx = setup.submit_and_wait(50_000).await?;
+    let pre_reorg_tip = setup.node.rpc_client.getbestblockhash().await?;
+
+    let mined = setup
+        .node
+        .rpc_client
+        .generate_to_address(
+            2,
+            &setup.node.mining_address.clone().into_unchecked(),
+        )
+        .await?;
+    let (b1, b2) = (mined[0], mined[1]);
+    anyhow::ensure!(
+        setup
+            .node
+            .rpc_client
+            .get_block(b1, bitcoin_jsonrpsee::client::U8Witness::<2>)
+            .await?
+            .tx
+            .iter()
+            .any(|t| t.txid == tx),
+        "expected B1 to confirm {tx}"
+    );
+    setup.wait_for_local_tip(b2, Duration::from_secs(5)).await?;
+
+    setup.node.rpc_client.invalidate_block(b1).await?;
+
+    wait_for_mempool_pred(
+        &setup.node.rpc_client,
+        Duration::from_secs(10),
+        |t| t.contains(&tx),
+        "tx back in bitcoind mempool",
+    )
+    .await?;
+    setup
+        .wait_for_local_tip(pre_reorg_tip, Duration::from_secs(10))
+        .await?;
+    setup
+        .wait_for_local_mempool(
+            Duration::from_secs(10),
+            |t| t.contains(&tx),
+            "tx re-inserted into local mempool",
+        )
+        .await?;
+
+    anyhow::ensure!(
+        setup.task_errors.is_empty(),
+        "task errors: {:?}",
+        setup.task_errors.snapshot()
+    );
+    anyhow::ensure!(
+        setup.enforcer.disconnect_block_calls() >= 2,
+        "expected ≥2 enforcer.disconnect_block calls"
+    );
+    Ok(())
+}

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -1,0 +1,382 @@
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::anyhow;
+use base64::Engine as _;
+use bitcoin::{Address, BlockHash, Txid};
+use bitcoin_jsonrpsee::{
+    MainClient as _,
+    jsonrpsee::{
+        core::{ClientError, client::ClientT},
+        http_client::{HeaderMap, HeaderValue, HttpClient, HttpClientBuilder},
+        rpc_params,
+    },
+};
+use parking_lot::Mutex;
+use thiserror::Error;
+use tokio::{process::Command, task::JoinHandle, time::sleep};
+
+/// JSON-RPC client targeting the test's bitcoind.
+pub type RpcClient = HttpClient;
+
+#[derive(Debug, Error)]
+#[error("Missing or invalid environment variable `{key}`: {err}")]
+pub struct VarError {
+    key: String,
+    err: std::env::VarError,
+}
+
+fn get_env_path(key: &str) -> Result<PathBuf, VarError> {
+    std::env::var(key)
+        .map(PathBuf::from)
+        .map_err(|err| VarError {
+            key: key.to_owned(),
+            err,
+        })
+}
+
+/// Lazily-resolved bin paths required by the integration tests.
+#[derive(Clone, Debug, Default)]
+pub struct BinPaths {
+    bitcoind: std::sync::OnceLock<PathBuf>,
+}
+
+impl BinPaths {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn bitcoind(&self) -> Result<&Path, VarError> {
+        if let Some(p) = self.bitcoind.get() {
+            return Ok(p);
+        }
+        let resolved = get_env_path("BITCOIND")?;
+        Ok(self.bitcoind.get_or_init(|| resolved))
+    }
+}
+
+/// Wrapper around `JoinHandle` that aborts the task on drop.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct AbortOnDrop<T>(JoinHandle<T>);
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        self.0.abort()
+    }
+}
+
+impl<T> From<JoinHandle<T>> for AbortOnDrop<T> {
+    fn from(task: JoinHandle<T>) -> Self {
+        Self(task)
+    }
+}
+
+/// Configuration for the `bitcoind` process spawned by an integration test.
+#[derive(Clone, Debug)]
+pub struct Bitcoind {
+    pub path: PathBuf,
+    pub data_dir: PathBuf,
+    pub listen_port: u16,
+    pub rpc_port: u16,
+    pub rpc_user: String,
+    pub rpc_pass: String,
+    pub zmq_sequence_port: u16,
+}
+
+impl Bitcoind {
+    pub fn spawn(&self) -> anyhow::Result<AbortOnDrop<()>> {
+        let args: Vec<OsString> = [
+            "-regtest".to_owned(),
+            "-server".to_owned(),
+            "-listenonion=0".to_owned(),
+            "-fallbackfee=0.00001".to_owned(),
+            "-acceptnonstdtxn=1".to_owned(),
+            "-txindex".to_owned(),
+            "-debug=mempool".to_owned(),
+            "-debug=rpc".to_owned(),
+            "-debug=zmq".to_owned(),
+            format!("-datadir={}", self.data_dir.display()),
+            format!("-bind=127.0.0.1:{}", self.listen_port),
+            format!("-rpcbind=127.0.0.1:{}", self.rpc_port),
+            "-rpcallowip=127.0.0.1".to_owned(),
+            format!("-rpcuser={}", self.rpc_user),
+            format!("-rpcpassword={}", self.rpc_pass),
+            format!(
+                "-zmqpubsequence=tcp://127.0.0.1:{}",
+                self.zmq_sequence_port
+            ),
+        ]
+        .into_iter()
+        .map(OsString::from)
+        .collect();
+
+        let stdout_file =
+            std::fs::File::create(self.data_dir.join("stdout.txt"))?;
+        let stderr_file =
+            std::fs::File::create(self.data_dir.join("stderr.txt"))?;
+
+        let mut cmd = Command::new(&self.path);
+        cmd.args(args);
+        cmd.stdout(std::process::Stdio::from(stdout_file));
+        cmd.stderr(std::process::Stdio::from(stderr_file));
+        cmd.kill_on_drop(true);
+
+        let mut child = cmd.spawn()?;
+        let task = tokio::spawn(async move {
+            // If bitcoind exits unexpectedly we just log; the test will fail
+            // when it can't reach the RPC port. We don't want to panic from a
+            // background task.
+            match child.wait().await {
+                Ok(status) => tracing::warn!(?status, "bitcoind exited"),
+                Err(err) => tracing::warn!(%err, "bitcoind wait failed"),
+            }
+        });
+        Ok(AbortOnDrop::from(task))
+    }
+
+    pub fn zmq_addr(&self) -> String {
+        format!("tcp://127.0.0.1:{}", self.zmq_sequence_port)
+    }
+
+    /// JSON-RPC client. If `wallet` is `Some`, the URL includes
+    /// `/wallet/<name>` so wallet-only RPCs (sendtoaddress, bumpfee, etc.)
+    /// are routed to that wallet.
+    pub fn http_client(
+        &self,
+        wallet: Option<&str>,
+    ) -> anyhow::Result<RpcClient> {
+        // bitcoin_jsonrpsee::client builds the URL without a path; for
+        // wallet-scoped calls we have to construct the builder ourselves.
+        const MAX_REQUEST_SIZE: u32 = 100 * (1 << 20);
+        const MAX_RESPONSE_SIZE: u32 = 1 << 30;
+        const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+        let auth = format!("{}:{}", self.rpc_user, self.rpc_pass);
+        let auth_value = format!(
+            "Basic {}",
+            base64::engine::general_purpose::STANDARD.encode(auth)
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", HeaderValue::from_str(&auth_value)?);
+
+        let url = match wallet {
+            Some(name) => {
+                format!("http://127.0.0.1:{}/wallet/{name}", self.rpc_port)
+            }
+            None => format!("http://127.0.0.1:{}", self.rpc_port),
+        };
+
+        Ok(HttpClientBuilder::default()
+            .max_request_size(MAX_REQUEST_SIZE)
+            .max_response_size(MAX_RESPONSE_SIZE)
+            .request_timeout(REQUEST_TIMEOUT)
+            .set_headers(headers)
+            .build(url)?)
+    }
+}
+
+/// Poll `getblockchaininfo` until bitcoind serves a successful response.
+pub async fn wait_for_bitcoind_ready(rpc: &RpcClient) -> anyhow::Result<()> {
+    const TOTAL_TIMEOUT: Duration = Duration::from_secs(30);
+    const POLL_INTERVAL: Duration = Duration::from_millis(200);
+    let deadline = tokio::time::Instant::now() + TOTAL_TIMEOUT;
+    loop {
+        if rpc.get_blockchain_info().await.is_ok() {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "bitcoind did not become ready within {TOTAL_TIMEOUT:?}"
+            ));
+        }
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Poll bitcoind's mempool until `predicate(txids)` returns true.
+pub async fn wait_for_mempool_pred<F>(
+    rpc: &RpcClient,
+    timeout_duration: Duration,
+    mut predicate: F,
+    label: &str,
+) -> anyhow::Result<()>
+where
+    F: FnMut(&[Txid]) -> bool,
+{
+    let deadline = tokio::time::Instant::now() + timeout_duration;
+    loop {
+        let txids = mempool_txids(rpc).await?;
+        if predicate(&txids) {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "timed out waiting for bitcoind mempool `{label}` after {timeout_duration:?}"
+            ));
+        }
+        sleep(Duration::from_millis(75)).await;
+    }
+}
+
+// Wallet/bitcoind RPCs not exposed by `MainClient`
+
+/// `createwallet <name>`.
+pub async fn create_wallet(
+    rpc: &RpcClient,
+    name: &str,
+) -> Result<(), ClientError> {
+    let _resp: serde_json::Value =
+        rpc.request("createwallet", rpc_params![name]).await?;
+    Ok(())
+}
+
+/// `sendtoaddress <addr> <amount>` — returns the new txid.
+pub async fn send_to_address(
+    rpc: &RpcClient,
+    addr: &Address,
+    amount_sat: u64,
+) -> anyhow::Result<Txid> {
+    let amount_btc = format!("{:.8}", (amount_sat as f64) / 100_000_000.0);
+    let txid: String = rpc
+        .request("sendtoaddress", rpc_params![addr.to_string(), amount_btc])
+        .await?;
+    Ok(txid.parse()?)
+}
+
+/// `bumpfee <txid>` — returns the replacement txid.
+pub async fn bump_fee(rpc: &RpcClient, txid: Txid) -> anyhow::Result<Txid> {
+    #[derive(serde::Deserialize)]
+    struct BumpFee {
+        txid: String,
+    }
+    let res: BumpFee = rpc
+        .request("bumpfee", rpc_params![txid.to_string()])
+        .await?;
+    Ok(res.txid.parse()?)
+}
+
+/// `generateblock <addr> <txids>` — mines a single block including exactly
+/// the given txs (use `[]` for an empty block of just coinbase).
+pub async fn generate_block(
+    rpc: &RpcClient,
+    addr: &Address,
+    txs: &[Txid],
+) -> anyhow::Result<BlockHash> {
+    let tx_strs: Vec<String> = txs.iter().map(|t| t.to_string()).collect();
+    let res: serde_json::Value = rpc
+        .request("generateblock", rpc_params![addr.to_string(), tx_strs])
+        .await?;
+    let hash = res["hash"]
+        .as_str()
+        .ok_or_else(|| anyhow!("generateblock missing `hash`: {res:?}"))?;
+    Ok(hash.parse()?)
+}
+
+/// `getnewaddress` — returns a fresh wallet address.
+pub async fn get_new_address(rpc: &RpcClient) -> anyhow::Result<Address> {
+    let s: String = rpc.request("getnewaddress", rpc_params![]).await?;
+    Ok(s.parse::<Address<_>>()?
+        .require_network(bitcoin::Network::Regtest)?)
+}
+
+/// Send `amount_sat` to a fresh address — `getnewaddress` + `sendtoaddress`.
+pub async fn submit_tx(
+    rpc: &RpcClient,
+    amount_sat: u64,
+) -> anyhow::Result<Txid> {
+    let dest = get_new_address(rpc).await?;
+    send_to_address(rpc, &dest, amount_sat).await
+}
+
+/// `getrawmempool` — bitcoind's current mempool as a list of txids.
+pub async fn mempool_txids(rpc: &RpcClient) -> anyhow::Result<Vec<Txid>> {
+    // We bypass MainClient::get_raw_mempool because its typed
+    // `Verbose`/`MempoolSequence` witnesses are unwieldy; a simple
+    // `Vec<String>` parse is all we need.
+    let txids: Vec<String> =
+        rpc.request("getrawmempool", rpc_params![]).await?;
+    txids
+        .into_iter()
+        .map(|s| s.parse::<Txid>().map_err(anyhow::Error::from))
+        .collect()
+}
+
+#[derive(Clone, Debug)]
+pub struct TestFailure {
+    pub test_name: String,
+    pub error: String,
+    /// Optional directory whose `stdout.txt` / `stderr.txt` should be
+    /// tailed onto the failure summary.
+    pub log_dir: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TestFailureCollector {
+    failures: Arc<Mutex<Vec<TestFailure>>>,
+}
+
+impl TestFailureCollector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_failure(&self, failure: TestFailure) {
+        self.failures.lock().push(failure);
+    }
+
+    /// Print a banner with each failure, followed by the last
+    /// lines of `stdout.txt` / `stderr.txt` from the failing
+    /// test's `log_dir` (if any).
+    #[expect(clippy::print_stderr)]
+    pub fn display_all_failures(&self) {
+        const TAIL_LINES: usize = 30;
+        let failures = self.failures.lock();
+        if failures.is_empty() {
+            return;
+        }
+        eprintln!("\n{}", "=".repeat(80));
+        eprintln!("TEST FAILURE SUMMARY ({} failed test(s))", failures.len());
+        eprintln!("{}", "=".repeat(80));
+        for (i, f) in failures.iter().enumerate() {
+            eprintln!("\n[{}] {}", i + 1, f.test_name);
+            eprintln!("    error: {}", f.error);
+            if let Some(dir) = &f.log_dir {
+                for stream in ["stdout.txt", "stderr.txt"] {
+                    let path = dir.join(stream);
+                    match read_file_tail(&path, TAIL_LINES) {
+                        Ok(content) if !content.trim().is_empty() => {
+                            eprintln!(
+                                "    --- bitcoind {stream} (last {TAIL_LINES} lines, {}) ---",
+                                path.display()
+                            );
+                            for line in content.lines() {
+                                eprintln!("    | {line}");
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(err) => eprintln!(
+                            "    --- failed to read {}: {err} ---",
+                            path.display()
+                        ),
+                    }
+                }
+            }
+        }
+        eprintln!("\n{}", "=".repeat(80));
+    }
+}
+
+fn read_file_tail(path: &Path, n: usize) -> Result<String, std::io::Error> {
+    let content = std::fs::read_to_string(path)?;
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.len() <= n {
+        Ok(content)
+    } else {
+        Ok(lines[lines.len() - n..].join("\n"))
+    }
+}

--- a/lib/cusf_enforcer.rs
+++ b/lib/cusf_enforcer.rs
@@ -357,8 +357,14 @@ where
 }
 
 /// Compose two [`CusfEnforcer`]s, left-before-right
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Compose<C0, C1>(pub(crate) C0, pub(crate) C1);
+
+impl<C0, C1> Compose<C0, C1> {
+    pub fn new(c0: C0, c1: C1) -> Self {
+        Self(c0, c1)
+    }
+}
 
 impl<C0, C1> CusfEnforcer for Compose<C0, C1>
 where

--- a/scripts/setup_integration_tests.sh
+++ b/scripts/setup_integration_tests.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Set up integration-test dependencies and write integrationtests.env.
+# Idempotent. Re-running re-uses cached artifacts.
+#
+# The cusf-enforcer-mempool tests only need a stock Bitcoin Core (for bitcoind
+# + bitcoin-cli) — no patched core, no electrs, no signet miner.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Deps live at the primary worktree so all worktrees of this clone share them.
+GIT_COMMON_DIR="$(cd "$REPO_ROOT" && git rev-parse --git-common-dir)"
+case "$GIT_COMMON_DIR" in
+    /*) ;;
+    *)  GIT_COMMON_DIR="$REPO_ROOT/$GIT_COMMON_DIR" ;;
+esac
+DEPS_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd)"
+DEPS_DIR="$DEPS_ROOT/.integration-deps"
+
+BITCOIN_VERSION="30.2"
+STOCK_DIR="$DEPS_DIR/bitcoin-stock-$BITCOIN_VERSION"
+
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+case "$OS-$ARCH" in
+    linux-x86_64)  STOCK_TARGET="x86_64-linux-gnu" ;;
+    linux-aarch64) STOCK_TARGET="aarch64-linux-gnu" ;;
+    darwin-x86_64) STOCK_TARGET="x86_64-apple-darwin" ;;
+    darwin-arm64)  STOCK_TARGET="arm64-apple-darwin" ;;
+    *) echo "Unsupported platform: $OS-$ARCH" >&2; exit 1 ;;
+esac
+
+mkdir -p "$DEPS_DIR"
+
+# --- Stock Bitcoin Core ---
+if [ ! -x "$STOCK_DIR/bitcoind" ]; then
+    echo "Downloading stock Bitcoin Core $BITCOIN_VERSION ($STOCK_TARGET)..."
+    TMP=$(mktemp -d)
+    trap 'rm -rf "$TMP"' EXIT
+    TARBALL="bitcoin-$BITCOIN_VERSION-$STOCK_TARGET.tar.gz"
+    curl -# -fL "https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$TARBALL" -o "$TMP/$TARBALL"
+    tar -C "$TMP" -xf "$TMP/$TARBALL"
+    rm -rf "$STOCK_DIR"
+    mv "$TMP/bitcoin-$BITCOIN_VERSION/bin" "$STOCK_DIR"
+    chmod +x "$STOCK_DIR"/bitcoind "$STOCK_DIR"/bitcoin-cli
+    rm -rf "$TMP"
+    trap - EXIT
+else
+    echo "Stock bitcoin: cached"
+fi
+
+# --- Write integrationtests.env ---
+ENV_FILE="$REPO_ROOT/integrationtests.env"
+cat > "$ENV_FILE" <<EOF
+BITCOIND='$STOCK_DIR/bitcoind'
+EOF
+
+echo
+echo "Wrote $ENV_FILE"
+echo "Deps cache: $DEPS_DIR"
+echo "Run integration tests with: just test-it"


### PR DESCRIPTION
Contains some tests of the base functionality of `cusf-enforcer-mempool` plus a few failing tests that identify bugs in PR 17.

These tests demonstrate several bugs: 

- `ApplySyncActionResult::from(removed)` when `removed=false` leads to stalling of the sync. Demonstrated in `test_rbf_removed_for_absent_tx`
- Double `mempool.insert()` calls leading to an error, demonstrated in `test_double_insert_after_reorg`
- Composed enforcers not behaving correctly. Demonstrated in `test_compose_drops_remove_mempool_txs`
- Rejected blocks leads to TXs dropped from our mempool but kept in the bitcoind mempool, which again leads to the same error case as in the first point in this list. Demonstrated in `test_enforcer_rejection_during_reorg`