### PR TITLE
Less cryptic error messages

### DIFF
--- a/lib/mempool/sync/initial_sync.rs
+++ b/lib/mempool/sync/initial_sync.rs
@@ -20,6 +20,7 @@ use super::{
     super::{Mempool, MempoolInsertError, MempoolRemoveError},
     BatchedResponseItem, CombinedStream, CombinedStreamItem, RequestError,
     RequestItem, RequestQueue, ResponseItem, SeqMessageQueue, batched_request,
+    task::{ApplySeqMessageTimeoutError, apply_seq_msg_timeout},
 };
 use crate::{
     cusf_enforcer::{self, ConnectBlockAction, CusfEnforcer},
@@ -84,8 +85,8 @@ pub enum SyncMempoolError<Enforcer>
 where
     Enforcer: CusfEnforcer,
 {
-    #[error("Timeout while waiting to apply sequence message")]
-    ApplySeqMessageTimeout,
+    #[error(transparent)]
+    ApplySeqMessageTimeout(#[from] ApplySeqMessageTimeoutError),
     #[error("Combined stream ended unexpectedly")]
     CombinedStreamEnded,
     // TODO - this is not really an error...
@@ -104,13 +105,13 @@ where
     FirstMempoolSequence(u64),
     #[error(transparent)]
     InitialSyncEnforcer(#[from] cusf_enforcer::InitialSyncError<Enforcer>),
-    #[error("RPC error")]
-    JsonRpc(#[from] JsonRpcError),
+    #[error("RPC error while fetching the raw mempool")]
+    GetRawMempool(#[source] JsonRpcError),
     #[error(transparent)]
     MempoolInsert(#[from] MempoolInsertError),
     #[error(transparent)]
     MempoolRemove(#[from] MempoolRemoveError),
-    #[error("Request error")]
+    #[error(transparent)]
     Request(#[from] RequestError),
     #[error("Sequence stream error")]
     SequenceStream(#[from] SequenceStreamError),
@@ -534,7 +535,8 @@ where
         mempool_sequence,
     } = rpc_client
         .get_raw_mempool(BoolWitness::<false>, BoolWitness::<true>)
-        .await?;
+        .await
+        .map_err(SyncMempoolError::GetRawMempool)?;
     let mut sync_state = {
         let request_queue = RequestQueue::default();
         request_queue.push_back(RequestItem::Block(best_block_hash));
@@ -569,22 +571,6 @@ where
         .then(|request| batched_request(rpc_client, request))
         .boxed();
 
-    let apply_seq_msg_timeout = |seq_msg_queue: &SeqMessageQueue| {
-        const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
-        let sleep_until = seq_msg_queue
-            .front()
-            .as_ref()
-            .map(|front| front.reached_head_time + TIMEOUT);
-        async move {
-            if let Some(sleep_until) = sleep_until {
-                tokio::time::sleep_until(sleep_until.into()).await
-            } else {
-                futures::future::pending().await
-            }
-        }
-        .boxed()
-    };
-
     // Pin the shutdown signal
     futures::pin_mut!(shutdown_signal);
 
@@ -611,7 +597,14 @@ where
                     apply_seq_msg_timeout(&sync_state.seq_message_queue).fuse();
             }
             CombinedStreamItem::ApplySeqMessageTimeout => {
-                return Err(SyncMempoolError::ApplySeqMessageTimeout);
+                let err = ApplySeqMessageTimeoutError {
+                    msg: sync_state
+                        .seq_message_queue
+                        .front()
+                        .as_ref()
+                        .map(|head| head.msg),
+                };
+                return Err(err.into());
             }
             CombinedStreamItem::Shutdown => {
                 return Err(SyncMempoolError::Shutdown);

--- a/lib/mempool/sync/mod.rs
+++ b/lib/mempool/sync/mod.rs
@@ -230,12 +230,35 @@ enum BatchedResponseItem {
     Single(ResponseItem),
 }
 
+impl BatchedRequestItem {
+    /// The bitcoind RPC method this request is dispatched as.
+    fn rpc_method(&self) -> &'static str {
+        match self {
+            Self::BatchRejectTx(_) | Self::Single(RequestItem::RejectTx(_)) => {
+                "prioritisetransaction"
+            }
+            Self::BatchTx(_) | Self::Single(RequestItem::Tx(..)) => {
+                "getrawtransaction"
+            }
+            Self::Single(RequestItem::Block(_)) => "getblock",
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum RequestError {
-    #[error("Error deserializing tx")]
-    DeserializeTx(#[from] bitcoin::consensus::encode::FromHexError),
-    #[error("RPC error")]
-    JsonRpc(#[from] JsonRpcError),
+    #[error("`{method}` RPC call failed")]
+    JsonRpc {
+        method: &'static str,
+        #[source]
+        source: JsonRpcError,
+    },
+    #[error("failed to deserialize `{method}` response")]
+    DeserializeResponse {
+        method: &'static str,
+        #[source]
+        source: bitcoin::consensus::encode::FromHexError,
+    },
 }
 
 async fn batched_request<RpcClient>(
@@ -246,6 +269,7 @@ where
     RpcClient: bitcoin_jsonrpsee::client::MainClient + Sync,
 {
     const NEGATIVE_MAX_SATS: i64 = -(21_000_000 * 100_000_000);
+    let method = request.rpc_method();
     match request {
         BatchedRequestItem::BatchRejectTx(txs) => {
             let mut request = BatchRequestBuilder::new();
@@ -261,9 +285,13 @@ where
                 .batch_request(request)
                 // Must box due to https://github.com/rust-lang/rust/issues/100013
                 .boxed()
-                .await?
+                .await
+                .map_err(|e| RequestError::JsonRpc { method, source: e })?
                 .into_ok()
-                .map_err(|mut errs| JsonRpcError::from(errs.next().unwrap()))?
+                .map_err(|mut errs| RequestError::JsonRpc {
+                    method,
+                    source: JsonRpcError::from(errs.next().unwrap()),
+                })?
                 .collect();
             Ok(BatchedResponseItem::BatchRejectTx)
         }
@@ -280,23 +308,31 @@ where
                 .batch_request(request)
                 // Must box due to https://github.com/rust-lang/rust/issues/100013
                 .boxed()
-                .await?
+                .await
+                .map_err(|e| RequestError::JsonRpc { method, source: e })?
                 .into_ok()
-                .map_err(|mut errs| JsonRpcError::from(errs.next().unwrap()))?
+                .map_err(|mut errs| RequestError::JsonRpc {
+                    method,
+                    source: JsonRpcError::from(errs.next().unwrap()),
+                })?
                 .map(|tx_hex: String| {
-                    bitcoin::consensus::encode::deserialize_hex(&tx_hex).map(
-                        |tx: Transaction| {
-                            let txid = tx.compute_txid();
-                            (tx, in_mempool[&txid])
-                        },
-                    )
+                    let tx: Transaction =
+                        bitcoin::consensus::encode::deserialize_hex(&tx_hex)
+                            .map_err(|e| RequestError::DeserializeResponse {
+                                method,
+                                source: e,
+                            })?;
+                    let txid = tx.compute_txid();
+                    Ok((tx, in_mempool[&txid]))
                 })
-                .collect::<Result<_, _>>()?;
+                .collect::<Result<_, RequestError>>()?;
             Ok(BatchedResponseItem::BatchTx(txs))
         }
         BatchedRequestItem::Single(RequestItem::Block(block_hash)) => {
-            let block =
-                rpc_client.get_block(block_hash, U8Witness::<2>).await?;
+            let block = rpc_client
+                .get_block(block_hash, U8Witness::<2>)
+                .await
+                .map_err(|e| RequestError::JsonRpc { method, source: e })?;
             let resp = ResponseItem::Block(Box::new(block));
             Ok(BatchedResponseItem::Single(resp))
         }
@@ -305,7 +341,8 @@ where
             // from mempool as soon as possible
             let _: bool = rpc_client
                 .prioritize_transaction(txid, NEGATIVE_MAX_SATS)
-                .await?;
+                .await
+                .map_err(|e| RequestError::JsonRpc { method, source: e })?;
             let resp = ResponseItem::RejectTx;
             Ok(BatchedResponseItem::Single(resp))
         }
@@ -316,9 +353,12 @@ where
                     GetRawTransactionVerbose::<false>,
                     None,
                 )
-                .await?;
+                .await
+                .map_err(|e| RequestError::JsonRpc { method, source: e })?;
             let tx: Transaction =
-                bitcoin::consensus::encode::deserialize_hex(&tx_hex)?;
+                bitcoin::consensus::encode::deserialize_hex(&tx_hex).map_err(
+                    |e| RequestError::DeserializeResponse { method, source: e },
+                )?;
             let resp = ResponseItem::Tx(Box::new(tx), in_mempool);
             Ok(BatchedResponseItem::Single(resp))
         }

--- a/lib/mempool/sync/task.rs
+++ b/lib/mempool/sync/task.rs
@@ -45,15 +45,40 @@ pub struct SyncState {
     tx_cache: HashMap<Txid, Transaction>,
 }
 
+/// Timeout waiting to apply the next sequence message before its dependencies
+/// were available.
+const APPLY_SEQ_MSG_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(15);
+
+/// Future that fires once the message at the head of `seq_msg_queue` has waited
+/// longer than APPLY_SEQ_MSG_TIMEOUT for its dependencies, or stays pending
+/// forever while the queue is empty.
+pub(super) fn apply_seq_msg_timeout(
+    seq_msg_queue: &SeqMessageQueue,
+) -> BoxFuture<'static, ()> {
+    let sleep_until = seq_msg_queue
+        .front()
+        .as_ref()
+        .map(|front| front.reached_head_time + APPLY_SEQ_MSG_TIMEOUT);
+    async move {
+        if let Some(sleep_until) = sleep_until {
+            tokio::time::sleep_until(sleep_until.into()).await
+        } else {
+            futures::future::pending().await
+        }
+    }
+    .boxed()
+}
+
 #[derive(Debug, Error)]
-#[repr(transparent)]
 pub struct ApplySeqMessageTimeoutError {
-    msg: Option<SequenceMessage>,
+    pub(super) msg: Option<SequenceMessage>,
 }
 
 impl std::fmt::Display for ApplySeqMessageTimeoutError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self { msg } = self;
+        let timeout = APPLY_SEQ_MSG_TIMEOUT;
         match msg {
             Some(SequenceMessage::BlockHash(block_hash_msg)) => {
                 let BlockHashMessage {
@@ -63,7 +88,7 @@ impl std::fmt::Display for ApplySeqMessageTimeoutError {
                 } = block_hash_msg;
                 write!(
                     f,
-                    "Timeout while waiting to apply sequence message (block {} {})",
+                    "Timeout after {timeout:?} while waiting to apply sequence message (block {} {})",
                     block_hash,
                     match event {
                         BlockHashEvent::Connected => "connected",
@@ -80,7 +105,7 @@ impl std::fmt::Display for ApplySeqMessageTimeoutError {
                 } = tx_hash_msg;
                 write!(
                     f,
-                    "Timeout while waiting to apply sequence message (tx {} {})",
+                    "Timeout after {timeout:?} while waiting to apply sequence message (tx {} {})",
                     txid,
                     match event {
                         TxHashEvent::Added => "added",
@@ -89,7 +114,10 @@ impl std::fmt::Display for ApplySeqMessageTimeoutError {
                 )
             }
             None => {
-                write!(f, "Timeout while waiting to apply sequence message")
+                write!(
+                    f,
+                    "Timeout after {timeout:?} while waiting to apply sequence message"
+                )
             }
         }
     }
@@ -126,7 +154,7 @@ where
     MempoolRemove(#[from] MempoolRemoveError),
     #[error(transparent)]
     MempoolUpdate(#[from] MempoolUpdateError),
-    #[error("Request error")]
+    #[error(transparent)]
     Request(#[from] RequestError),
     #[error("Sequence stream error")]
     SequenceStream(#[from] SequenceStreamError),
@@ -698,22 +726,6 @@ where
         .then(|request| batched_request(&rpc_client, request))
         .boxed();
 
-    let apply_seq_msg_timeout = |seq_msg_queue: &SeqMessageQueue| {
-        const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
-        let sleep_until = seq_msg_queue
-            .front()
-            .as_ref()
-            .map(|front| front.reached_head_time + TIMEOUT);
-        async move {
-            if let Some(sleep_until) = sleep_until {
-                tokio::time::sleep_until(sleep_until.into()).await
-            } else {
-                futures::future::pending().await
-            }
-        }
-        .boxed()
-    };
-
     let mut combined_stream = CombinedStream::new(
         sequence_stream,
         response_stream,
@@ -751,7 +763,8 @@ where
                     apply_seq_msg_timeout(&sync_state.seq_message_queue).fuse();
             }
             CombinedStreamItem::Response(resp) => {
-                handle_resp(&inner, &mut sync_state, resp?)
+                let resp = resp.map_err(SyncTaskError::Request)?;
+                handle_resp(&inner, &mut sync_state, resp)
                     .instrument(span)
                     .await?;
                 combined_stream.apply_seq_msg_timeout =
@@ -759,7 +772,11 @@ where
             }
             CombinedStreamItem::ApplySeqMessageTimeout => {
                 let err = ApplySeqMessageTimeoutError {
-                    msg: sync_state.seq_message_queue.pop_front(),
+                    msg: sync_state
+                        .seq_message_queue
+                        .front()
+                        .as_ref()
+                        .map(|head| head.msg),
                 };
                 return Err(err.into());
             }

--- a/lib/zmq.rs
+++ b/lib/zmq.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use bitcoin::{BlockHash, Txid, hashes::Hash as _};
+use bitcoin::{BlockHash, Txid, hashes::Hash as _, hex::DisplayHex as _};
 use futures::{
     Stream, StreamExt, TryStreamExt as _,
     stream::{self, BoxStream},
@@ -81,73 +81,86 @@ impl TryFrom<ZmqMessage> for SequenceMessage {
     type Error = DeserializeSequenceMessageError;
 
     fn try_from(msg: ZmqMessage) -> Result<Self, Self::Error> {
-        let msgs = &msg.into_vec();
-        let Some(b"sequence") = msgs.first().map(|msg| &**msg) else {
-            return Err(Self::Error::MissingPrefix);
-        };
-        let Some((hash, rest)) =
-            msgs.get(1).and_then(|msg| msg.split_first_chunk())
-        else {
-            return Err(Self::Error::MissingHash);
-        };
-        let mut hash = *hash;
-        hash.reverse();
-        let Some(([message_type], rest)) = rest.split_first_chunk() else {
-            return Err(Self::Error::MissingMessageType);
-        };
-        let Some((zmq_seq, _rest)) =
-            msgs.get(2).and_then(|msg| msg.split_first_chunk())
-        else {
-            return Err(Self::Error::MissingZmqSequence);
-        };
-        let zmq_seq = u32::from_le_bytes(*zmq_seq);
-        let res = match *message_type {
-            b'C' => Self::BlockHash(BlockHashMessage {
-                block_hash: BlockHash::from_byte_array(hash),
-                event: BlockHashEvent::Connected,
-                zmq_seq,
-            }),
-            b'D' => Self::BlockHash(BlockHashMessage {
-                block_hash: BlockHash::from_byte_array(hash),
-                event: BlockHashEvent::Disconnected,
-                zmq_seq,
-            }),
-            b'A' => {
-                let Some((mempool_seq, _rest)) = rest.split_first_chunk()
-                else {
-                    return Err(Self::Error::MissingMempoolSequence);
-                };
-                Self::TxHash(TxHashMessage {
-                    txid: Txid::from_byte_array(hash),
-                    event: TxHashEvent::Added,
-                    mempool_seq: u64::from_le_bytes(*mempool_seq),
-                    zmq_seq,
-                })
-            }
-            b'R' => {
-                let Some((mempool_seq, _rest)) = rest.split_first_chunk()
-                else {
-                    return Err(Self::Error::MissingMempoolSequence);
-                };
-                SequenceMessage::TxHash(TxHashMessage {
-                    txid: Txid::from_byte_array(hash),
-                    event: TxHashEvent::Removed,
-                    mempool_seq: u64::from_le_bytes(*mempool_seq),
-                    zmq_seq,
-                })
-            }
-            message_type => {
-                return Err(Self::Error::UnknownMessageType(message_type));
-            }
-        };
-        Ok(res)
+        parse_sequence_message(&msg.into_vec())
     }
+}
+
+fn parse_sequence_message<T: AsRef<[u8]>>(
+    frames: &[T],
+) -> Result<SequenceMessage, DeserializeSequenceMessageError> {
+    use DeserializeSequenceMessageError as Error;
+    let Some(b"sequence") = frames.first().map(|frame| frame.as_ref()) else {
+        return Err(Error::MissingPrefix);
+    };
+    let Some((hash, rest)) = frames
+        .get(1)
+        .and_then(|frame| frame.as_ref().split_first_chunk())
+    else {
+        return Err(Error::MissingHash);
+    };
+    let mut hash = *hash;
+    hash.reverse();
+    let Some(([message_type], rest)) = rest.split_first_chunk() else {
+        return Err(Error::MissingMessageType);
+    };
+    let Some((zmq_seq, _rest)) = frames
+        .get(2)
+        .and_then(|frame| frame.as_ref().split_first_chunk())
+    else {
+        return Err(Error::MissingZmqSequence);
+    };
+    let zmq_seq = u32::from_le_bytes(*zmq_seq);
+    let res = match *message_type {
+        b'C' => SequenceMessage::BlockHash(BlockHashMessage {
+            block_hash: BlockHash::from_byte_array(hash),
+            event: BlockHashEvent::Connected,
+            zmq_seq,
+        }),
+        b'D' => SequenceMessage::BlockHash(BlockHashMessage {
+            block_hash: BlockHash::from_byte_array(hash),
+            event: BlockHashEvent::Disconnected,
+            zmq_seq,
+        }),
+        b'A' => {
+            let Some((mempool_seq, _rest)) = rest.split_first_chunk() else {
+                return Err(Error::MissingMempoolSequence);
+            };
+            SequenceMessage::TxHash(TxHashMessage {
+                txid: Txid::from_byte_array(hash),
+                event: TxHashEvent::Added,
+                mempool_seq: u64::from_le_bytes(*mempool_seq),
+                zmq_seq,
+            })
+        }
+        b'R' => {
+            let Some((mempool_seq, _rest)) = rest.split_first_chunk() else {
+                return Err(Error::MissingMempoolSequence);
+            };
+            SequenceMessage::TxHash(TxHashMessage {
+                txid: Txid::from_byte_array(hash),
+                event: TxHashEvent::Removed,
+                mempool_seq: u64::from_le_bytes(*mempool_seq),
+                zmq_seq,
+            })
+        }
+        message_type => {
+            return Err(Error::UnknownMessageType(message_type));
+        }
+    };
+    Ok(res)
 }
 
 #[derive(Debug, Error)]
 pub enum SequenceStreamError {
-    #[error("Error deserializing message")]
-    Deserialize(#[from] DeserializeSequenceMessageError),
+    #[error(
+        "failed to deserialize ZMQ sequence message from frames {frames:?}"
+    )]
+    Deserialize {
+        /// Hex-encoded frames, for diagnostics.
+        frames: Vec<String>,
+        #[source]
+        source: DeserializeSequenceMessageError,
+    },
     #[error(
         "Expected message with mempool sequence at least {min_next_seq}, but received {seq}"
     )]
@@ -156,8 +169,12 @@ pub enum SequenceStreamError {
     MissingMempoolSequence(u64),
     #[error("Missing message with zmq sequence {0}")]
     MissingZmqSequence(u32),
-    #[error("ZMQ error")]
-    Zmq(#[from] ZmqError),
+    #[error("failed to receive message on ZMQ `{topic}` stream")]
+    Recv {
+        topic: String,
+        #[source]
+        source: ZmqError,
+    },
 }
 
 pub struct SequenceStream<'a>(
@@ -271,10 +288,27 @@ fn check_seq_numbers(
 
 #[derive(Debug, Error)]
 pub enum SubscribeSequenceError {
-    #[error("Connection timeout")]
-    Timeout(#[from] tokio::time::error::Elapsed),
-    #[error(transparent)]
-    Zmq(#[from] ZmqError),
+    #[error(
+        "ZMQ connection timeout after {timeout:?} connecting to `{target}`"
+    )]
+    Timeout {
+        target: String,
+        timeout: Duration,
+        #[source]
+        source: tokio::time::error::Elapsed,
+    },
+    #[error("failed to connect to ZMQ server at `{target}`")]
+    Connect {
+        target: String,
+        #[source]
+        source: ZmqError,
+    },
+    #[error("failed to subscribe to ZMQ topic `{topic}`")]
+    Subscribe {
+        topic: String,
+        #[source]
+        source: ZmqError,
+    },
 }
 
 /// Subscribe to ZMQ sequence stream.
@@ -290,13 +324,45 @@ pub async fn subscribe_sequence<'a>(
     const CONNECTION_TIMEOUT: Duration = Duration::from_secs(15);
     let mut socket = zeromq::SubSocket::new();
     tokio::time::timeout(CONNECTION_TIMEOUT, socket.connect(zmq_addr_sequence))
-        .await??;
+        .await
+        .map_err(|source| SubscribeSequenceError::Timeout {
+            target: zmq_addr_sequence.to_string(),
+            timeout: CONNECTION_TIMEOUT,
+            source,
+        })?
+        .map_err(|source| SubscribeSequenceError::Connect {
+            target: zmq_addr_sequence.to_string(),
+            source,
+        })?;
     tracing::info!("Connected to ZMQ server");
-    tracing::debug!("Attempting to subscribe to `sequence` topic...");
-    socket.subscribe("sequence").await?;
-    tracing::info!("Subscribed to `sequence`");
+
+    const TOPIC: &str = "sequence";
+    tracing::debug!("Attempting to subscribe to `{TOPIC}` topic...");
+
+    socket.subscribe(TOPIC).await.map_err(|source| {
+        SubscribeSequenceError::Subscribe {
+            topic: TOPIC.to_string(),
+            source,
+        }
+    })?;
+    tracing::info!("Subscribed to `{TOPIC}`");
     let inner = stream::try_unfold(socket, |mut socket| async {
-        let msg: SequenceMessage = socket.recv().await?.try_into()?;
+        let raw = socket.recv().await.map_err(|source| {
+            SequenceStreamError::Recv {
+                topic: TOPIC.to_string(),
+                source,
+            }
+        })?;
+        let frames = raw.into_vec();
+        let msg = parse_sequence_message(&frames).map_err(|source| {
+            SequenceStreamError::Deserialize {
+                frames: frames
+                    .iter()
+                    .map(|frame| frame.as_ref().to_lower_hex_string())
+                    .collect(),
+                source,
+            }
+        })?;
         Ok(Some((msg, socket)))
     })
     .try_filter_map({


### PR DESCRIPTION
Try to give all currently obtuse error messages enough context to actually underestand what's going on. An example: prior to this commit a ZMQ timout gave "Connection timeout: deadline has elapsed". Hard to understand that this is even a ZMQ issue!