### PR TITLE
Fallback when getmininginfo omits next target

### DIFF
--- a/lib/server.rs
+++ b/lib/server.rs
@@ -730,7 +730,12 @@ where
                     .get_mining_info()
                     .await
                     .map_err(internal_error)?;
-                let target = mining_info.next.target;
+                let target = mining_info
+                    .next
+                    .map(|next| next.target)
+                    .unwrap_or_else(|| {
+                        bitcoin::Target::from_be_bytes(self.sample_block_template.target)
+                    });
                 self.known_targets.write().insert(prev_blockhash, target);
                 target
             }


### PR DESCRIPTION
## Summary\n- Handle Bitcoin Core getmininginfo responses that omit next\n- Fall back to the sample block template target when constructing enforcer GBT responses\n\n## Test\n- cargo check -p cusf-enforcer-mempool