### PR TITLE
Handle missing next mining target

### DIFF
--- a/lib/server.rs
+++ b/lib/server.rs
@@ -730,7 +730,14 @@ where
                     .get_mining_info()
                     .await
                     .map_err(internal_error)?;
-                let target = mining_info.next.target;
+                let target = mining_info
+                    .next
+                    .ok_or_else(|| {
+                        internal_error(anyhow::anyhow!(
+                            "getmininginfo response missing next target"
+                        ))
+                    })?
+                    .target;
                 self.known_targets.write().insert(prev_blockhash, target);
                 target
             }


### PR DESCRIPTION
## Summary

- handle `get_mining_info().next` being absent when falling back to mining info for a block template target
- return an internal RPC error instead of failing to compile against the current `MiningInfo` shape

## Test

- `cargo check`