### PR TITLE
multi: add block proposal validation

### DIFF
--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -1,3 +1,4 @@
+pub mod mock_block_producer;
 pub mod mock_enforcer;
 pub mod setup;
 pub mod test_accept_tx_paths;
@@ -6,4 +7,5 @@ pub mod test_double_insert_after_reorg;
 pub mod test_enforcer_rejection_during_reorg;
 pub mod test_rbf_removed_for_absent_tx;
 pub mod test_reorg_re_inserts_tx;
+pub mod test_validate_block_proposal;
 pub mod util;

--- a/integration_tests/main.rs
+++ b/integration_tests/main.rs
@@ -6,6 +6,7 @@ use cusf_enforcer_mempool_integration_tests::{
     test_accept_tx_paths, test_block_connect_smoke,
     test_double_insert_after_reorg, test_enforcer_rejection_during_reorg,
     test_rbf_removed_for_absent_tx, test_reorg_re_inserts_tx,
+    test_validate_block_proposal,
     util::{BinPaths, TestFailure, TestFailureCollector},
 };
 use libtest_mimic::{Arguments, Trial};
@@ -184,6 +185,13 @@ fn run() -> anyhow::Result<std::process::ExitCode> {
         ("double_insert_after_reorg", |bp, dirs| {
             Box::pin(
                 test_double_insert_after_reorg::test_double_insert_after_reorg(
+                    bp, dirs,
+                ),
+            )
+        }),
+        ("validate_block_proposal", |bp, dirs| {
+            Box::pin(
+                test_validate_block_proposal::test_validate_block_proposal(
                     bp, dirs,
                 ),
             )

--- a/integration_tests/mock_block_producer.rs
+++ b/integration_tests/mock_block_producer.rs
@@ -1,0 +1,183 @@
+//! A mock [`CusfBlockProducer`] for integration tests: delegates enforcer
+//! behavior to a [`MockEnforcer`], adds passthrough template hooks, and lets
+//! tests declare proposal txs invalid from outside while the server is
+//! running.
+
+use std::{
+    borrow::Borrow,
+    collections::{HashMap, HashSet},
+    convert::Infallible,
+    future::Future,
+    sync::Arc,
+};
+
+use bitcoin::{BlockHash, Transaction, Txid};
+use cusf_enforcer_mempool::{
+    cusf_block_producer::{
+        BlockTemplateSuffix, CoinbaseTxn, CusfBlockProducer,
+        InitialBlockTemplate, ProposalValidity, typewit,
+    },
+    cusf_enforcer::{
+        ConnectBlockAction, CusfEnforcer, DisconnectBlockAction, TxAcceptAction,
+    },
+};
+use parking_lot::Mutex;
+
+use crate::mock_enforcer::MockEnforcer;
+
+#[derive(Default)]
+struct MockBlockProducerInner {
+    /// Proposals containing any of these txs are declared invalid due to
+    /// that tx
+    invalid_proposal_txids: HashSet<Txid>,
+    /// If set, every proposal is declared invalid due to this txid,
+    /// regardless of whether it is in the proposal
+    force_invalid_txid: Option<Txid>,
+    /// Proposal txids that `block_template_suffix` was invoked with, per
+    /// call
+    suffix_proposals: Vec<Vec<Txid>>,
+}
+
+#[derive(Clone, Default)]
+pub struct MockBlockProducer {
+    pub enforcer: MockEnforcer,
+    inner: Arc<Mutex<MockBlockProducerInner>>,
+}
+
+impl MockBlockProducer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Declare proposals containing `txid` invalid due to it
+    pub fn set_invalid_proposal_txid(&self, txid: Txid) {
+        self.inner.lock().invalid_proposal_txids.insert(txid);
+    }
+
+    pub fn clear_invalid_proposal_txids(&self) {
+        self.inner.lock().invalid_proposal_txids.clear();
+    }
+
+    /// Declare every proposal invalid due to `txid`, even if it is not in
+    /// the proposal
+    pub fn set_force_invalid_txid(&self, txid: Option<Txid>) {
+        self.inner.lock().force_invalid_txid = txid;
+    }
+
+    /// Proposal txids that `block_template_suffix` was invoked with, per
+    /// call
+    pub fn suffix_proposals(&self) -> Vec<Vec<Txid>> {
+        self.inner.lock().suffix_proposals.clone()
+    }
+}
+
+impl CusfEnforcer for MockBlockProducer {
+    type SyncError = <MockEnforcer as CusfEnforcer>::SyncError;
+
+    fn sync_to_tip<Signal: Future<Output = ()> + Send>(
+        &mut self,
+        shutdown_signal: Signal,
+        tip: BlockHash,
+    ) -> impl Future<Output = Result<(), Self::SyncError>> + Send {
+        self.enforcer.sync_to_tip(shutdown_signal, tip)
+    }
+
+    type ConnectBlockError = <MockEnforcer as CusfEnforcer>::ConnectBlockError;
+
+    fn connect_block(
+        &mut self,
+        block: &bitcoin::Block,
+    ) -> impl Future<
+        Output = Result<ConnectBlockAction, Self::ConnectBlockError>,
+    > + Send {
+        self.enforcer.connect_block(block)
+    }
+
+    type DisconnectBlockError =
+        <MockEnforcer as CusfEnforcer>::DisconnectBlockError;
+
+    fn disconnect_block(
+        &mut self,
+        block_hash: BlockHash,
+    ) -> impl Future<
+        Output = Result<DisconnectBlockAction, Self::DisconnectBlockError>,
+    > + Send {
+        self.enforcer.disconnect_block(block_hash)
+    }
+
+    type AcceptTxError = <MockEnforcer as CusfEnforcer>::AcceptTxError;
+
+    fn accept_tx<TxRef>(
+        &mut self,
+        tx: &Transaction,
+        tx_inputs: &HashMap<Txid, TxRef>,
+    ) -> Result<TxAcceptAction, Self::AcceptTxError>
+    where
+        TxRef: Borrow<Transaction>,
+    {
+        self.enforcer.accept_tx(tx, tx_inputs)
+    }
+}
+
+impl CusfBlockProducer for MockBlockProducer {
+    type InitialBlockTemplateError = Infallible;
+
+    async fn initial_block_template<const COINBASE_TXN: bool>(
+        &self,
+        _parent_block_hash: &BlockHash,
+        _coinbase_txn_wit: typewit::const_marker::BoolWit<COINBASE_TXN>,
+        template: InitialBlockTemplate<COINBASE_TXN>,
+    ) -> Result<
+        InitialBlockTemplate<COINBASE_TXN>,
+        Self::InitialBlockTemplateError,
+    >
+    where
+        typewit::const_marker::Bool<COINBASE_TXN>: CoinbaseTxn,
+    {
+        Ok(template)
+    }
+
+    type ValidateBlockProposalError = Infallible;
+
+    async fn validate_block_proposal<const COINBASE_TXN: bool>(
+        &self,
+        _parent_block_hash: &BlockHash,
+        _coinbase_txn_wit: typewit::const_marker::BoolWit<COINBASE_TXN>,
+        template: &InitialBlockTemplate<COINBASE_TXN>,
+    ) -> Result<ProposalValidity, Self::ValidateBlockProposalError>
+    where
+        typewit::const_marker::Bool<COINBASE_TXN>: CoinbaseTxn,
+    {
+        let inner = self.inner.lock();
+        if let Some(forced) = inner.force_invalid_txid {
+            return Ok(ProposalValidity::InvalidTx(forced));
+        }
+        for (tx, _fee) in &template.prefix_txs {
+            let txid = tx.compute_txid();
+            if inner.invalid_proposal_txids.contains(&txid) {
+                return Ok(ProposalValidity::InvalidTx(txid));
+            }
+        }
+        Ok(ProposalValidity::Valid)
+    }
+
+    type SuffixTxsError = Infallible;
+
+    async fn block_template_suffix<const COINBASE_TXN: bool>(
+        &self,
+        _parent_block_hash: &BlockHash,
+        _coinbase_txn_wit: typewit::const_marker::BoolWit<COINBASE_TXN>,
+        template: &InitialBlockTemplate<COINBASE_TXN>,
+    ) -> Result<BlockTemplateSuffix<COINBASE_TXN>, Self::SuffixTxsError>
+    where
+        typewit::const_marker::Bool<COINBASE_TXN>: CoinbaseTxn,
+    {
+        let proposal_txids = template
+            .prefix_txs
+            .iter()
+            .map(|(tx, _fee)| tx.compute_txid())
+            .collect();
+        self.inner.lock().suffix_proposals.push(proposal_txids);
+        Ok(BlockTemplateSuffix::default())
+    }
+}

--- a/integration_tests/test_validate_block_proposal.rs
+++ b/integration_tests/test_validate_block_proposal.rs
@@ -1,0 +1,209 @@
+//! A tx can be valid in isolation, yet invalid in the context of a block
+//! proposal. Tts validity can depend on state that an earlier tx in the
+//! proposal modifies. Such a tx is accepted into the mempool, so without 
+//! proposal validation it ends up in every block proposal, every `getblocktemplate` 
+//! call fails, and block production is blocked.
+//!
+//! [`CusfBlockProducer::validate_block_proposal`] lets the block producer
+//! identify the offending tx, so that the server excludes it (and its
+//! descendants) from the proposal and serves a valid template instead.
+
+use std::{collections::HashSet, time::Duration};
+
+use anyhow::{Context as _, anyhow};
+use bitcoin::{Address, Txid, hashes::Hash as _};
+use bitcoin_jsonrpsee::{
+    MainClient as _,
+    client::BlockTemplateRequest,
+    jsonrpsee::{core::client::ClientT, rpc_params},
+};
+use cusf_enforcer_mempool::server::{RpcServer as _, Server};
+
+use crate::{
+    mock_block_producer::MockBlockProducer,
+    setup::{
+        Directories, RegtestNode, start_mempool_sync, wait_for_local_mempool,
+    },
+    util::{BinPaths, RpcClient, get_new_address, send_to_address, submit_tx},
+};
+
+const WAIT: Duration = Duration::from_secs(15);
+
+/// Vout of `txid` paying to `addr`
+async fn find_vout_paying(
+    rpc: &RpcClient,
+    txid: Txid,
+    addr: &Address,
+) -> anyhow::Result<u32> {
+    let tx: serde_json::Value = rpc
+        .request("getrawtransaction", rpc_params![txid.to_string(), true])
+        .await?;
+    let addr = addr.to_string();
+    tx["vout"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find_map(|vout| {
+            if vout["scriptPubKey"]["address"].as_str() == Some(&addr) {
+                vout["n"].as_u64().map(|n| n as u32)
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| anyhow!("no output of `{txid}` pays to `{addr}`"))
+}
+
+/// Spend `parent_txid:parent_vout` to a fresh wallet address via the raw tx
+/// RPCs, deterministically chaining a child on an unconfirmed parent
+async fn send_child_spending(
+    rpc: &RpcClient,
+    parent_txid: Txid,
+    parent_vout: u32,
+    output_sat: u64,
+) -> anyhow::Result<Txid> {
+    let dest = get_new_address(rpc).await?;
+    let inputs = serde_json::json!([{
+        "txid": parent_txid.to_string(),
+        "vout": parent_vout,
+    }]);
+    let amount_btc = format!("{:.8}", (output_sat as f64) / 100_000_000.0);
+    let outputs = serde_json::json!({ dest.to_string(): amount_btc });
+    let raw: String = rpc
+        .request("createrawtransaction", rpc_params![inputs, outputs])
+        .await?;
+    #[derive(serde::Deserialize)]
+    struct Signed {
+        hex: String,
+        complete: bool,
+    }
+    let signed: Signed = rpc
+        .request("signrawtransactionwithwallet", rpc_params![raw])
+        .await?;
+    anyhow::ensure!(signed.complete, "signing child tx incomplete");
+    let txid: String = rpc
+        .request("sendrawtransaction", rpc_params![signed.hex])
+        .await?;
+    Ok(txid.parse()?)
+}
+
+/// Txids included in a `getblocktemplate` response from `server`
+async fn template_txids(
+    server: &Server<MockBlockProducer, RpcClient>,
+) -> anyhow::Result<HashSet<Txid>> {
+    let template = server
+        .get_block_template(BlockTemplateRequest::default())
+        .await
+        .context("getblocktemplate")?;
+    Ok(template.transactions.iter().map(|tx| tx.txid).collect())
+}
+
+pub async fn test_validate_block_proposal(
+    bin_paths: BinPaths,
+    directories: Directories,
+) -> anyhow::Result<()> {
+    let node = RegtestNode::new(&bin_paths, directories).await?;
+    let block_producer = MockBlockProducer::new();
+    let (mempool_sync, task_errors) =
+        start_mempool_sync(&node, block_producer.clone()).await?;
+
+    // A parent with a child chained on it, plus an unrelated tx
+    let parent_dest = get_new_address(&node.rpc_client).await?;
+    let parent =
+        send_to_address(&node.rpc_client, &parent_dest, 100_000).await?;
+    let parent_vout =
+        find_vout_paying(&node.rpc_client, parent, &parent_dest).await?;
+    let child =
+        send_child_spending(&node.rpc_client, parent, parent_vout, 80_000)
+            .await?;
+    let unrelated = submit_tx(&node.rpc_client, 50_000).await?;
+    tracing::info!(%parent, %child, %unrelated, "submitted txs");
+    let () = wait_for_local_mempool(
+        &mempool_sync,
+        &task_errors,
+        WAIT,
+        |txids| {
+            [parent, child, unrelated]
+                .iter()
+                .all(|txid| txids.contains(txid))
+        },
+        "all txs in local mempool",
+    )
+    .await?;
+
+    let network_info = node.rpc_client.get_network_info().await?;
+    let sample_block_template = node
+        .rpc_client
+        .get_block_template(BlockTemplateRequest::default())
+        .await
+        .context("sample getblocktemplate")?;
+    let server = Server::new(
+        node.mining_address.script_pubkey(),
+        mempool_sync,
+        bitcoin::Network::Regtest,
+        network_info,
+        node.rpc_client.clone(),
+        None,
+        sample_block_template,
+    )?;
+
+    // Control: all txs are proposed
+    let txids = template_txids(&server).await?;
+    for txid in [parent, child, unrelated] {
+        anyhow::ensure!(
+            txids.contains(&txid),
+            "control template missing `{txid}`"
+        );
+    }
+
+    // The parent is now invalid in the context of any proposal containing
+    // it. `getblocktemplate` must still succeed — with the parent and its
+    // child excluded — instead of failing on every call.
+    block_producer.set_invalid_proposal_txid(parent);
+    let txids = template_txids(&server).await?;
+    anyhow::ensure!(
+        !txids.contains(&parent),
+        "template contains invalid tx `{parent}`"
+    );
+    anyhow::ensure!(
+        !txids.contains(&child),
+        "template contains descendant `{child}` of invalid tx"
+    );
+    anyhow::ensure!(
+        txids.contains(&unrelated),
+        "template missing valid tx `{unrelated}`"
+    );
+    // The suffix hook only ever sees validated proposals
+    let suffix_proposals = block_producer.suffix_proposals();
+    let last_suffix_proposal = suffix_proposals
+        .last()
+        .ok_or_else(|| anyhow!("no suffix proposals recorded"))?;
+    anyhow::ensure!(
+        !last_suffix_proposal.contains(&parent)
+            && !last_suffix_proposal.contains(&child),
+        "`block_template_suffix` saw an unvalidated proposal: \
+         {last_suffix_proposal:?}"
+    );
+
+    // The mempool is not mutated: clearing the verdict restores the txs
+    block_producer.clear_invalid_proposal_txids();
+    let txids = template_txids(&server).await?;
+    for txid in [parent, child, unrelated] {
+        anyhow::ensure!(
+            txids.contains(&txid),
+            "template missing `{txid}` after clearing verdicts"
+        );
+    }
+
+    // An invalid tx that cannot be excluded from the proposal (not a
+    // proposal tx) must fail template generation, not loop forever
+    let absent_txid = Txid::from_byte_array([0xAB; 32]);
+    block_producer.set_force_invalid_txid(Some(absent_txid));
+    anyhow::ensure!(
+        template_txids(&server).await.is_err(),
+        "getblocktemplate should fail when the invalid tx cannot be excluded"
+    );
+    block_producer.set_force_invalid_txid(None);
+
+    let () = task_errors.ensure_empty("end of test")?;
+    Ok(())
+}

--- a/lib/cusf_block_producer.rs
+++ b/lib/cusf_block_producer.rs
@@ -61,6 +61,17 @@ where typewit::const_marker::Bool<COINBASE_TXN>: CoinbaseTxn
     pub txs: Vec<(Transaction, bitcoin::Amount)>,
 }
 
+/// Result of validating a block proposal via
+/// [`CusfBlockProducer::validate_block_proposal`]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProposalValidity {
+    Valid,
+    /// The proposal is invalid due to the specified tx.
+    /// The tx (and its descendants) will be excluded from the proposal,
+    /// before validating again.
+    InvalidTx(Txid),
+}
+
 pub trait CusfBlockProducer: CusfEnforcer {
     type InitialBlockTemplateError: std::error::Error + Send + Sync + 'static;
 
@@ -74,6 +85,28 @@ pub trait CusfBlockProducer: CusfEnforcer {
             InitialBlockTemplate<COINBASE_TXN>,
             Self::InitialBlockTemplateError,
         >,
+    > + Send
+    where
+        typewit::const_marker::Bool<COINBASE_TXN>: CoinbaseTxn;
+
+    type ValidateBlockProposalError: std::error::Error + Send + Sync + 'static;
+
+    /// Validate a block proposal, before computing the template suffix.
+    /// `template.prefix_txs` includes the proposed mempool txs.
+    ///
+    /// A tx can be valid in isolation, yet invalid in the context of a
+    /// specific block (e.g. a tx whose validity depends on state that an
+    /// earlier tx in the proposal modifies). Identifying such a tx via
+    /// [`ProposalValidity::InvalidTx`] excludes it (and its descendants)
+    /// from the proposal, after which validation runs again, rather than
+    /// failing block production entirely.
+    fn validate_block_proposal<const COINBASE_TXN: bool>(
+        &self,
+        parent_block_hash: &BlockHash,
+        coinbase_txn_wit: typewit::const_marker::BoolWit<COINBASE_TXN>,
+        template: &InitialBlockTemplate<COINBASE_TXN>,
+    ) -> impl Future<
+        Output = Result<ProposalValidity, Self::ValidateBlockProposalError>,
     > + Send
     where
         typewit::const_marker::Bool<COINBASE_TXN>: CoinbaseTxn;
@@ -133,6 +166,41 @@ where
             )
             .await
             .map_err(Either::Right)
+    }
+
+    type ValidateBlockProposalError =
+        Either<C0::ValidateBlockProposalError, C1::ValidateBlockProposalError>;
+
+    async fn validate_block_proposal<const COINBASE_TXN: bool>(
+        &self,
+        parent_block_hash: &BlockHash,
+        coinbase_txn_wit: typewit::const_marker::BoolWit<COINBASE_TXN>,
+        template: &InitialBlockTemplate<COINBASE_TXN>,
+    ) -> Result<ProposalValidity, Self::ValidateBlockProposalError>
+    where
+        typewit::const_marker::Bool<COINBASE_TXN>: CoinbaseTxn,
+    {
+        match self
+            .0
+            .validate_block_proposal(
+                parent_block_hash,
+                coinbase_txn_wit,
+                template,
+            )
+            .await
+            .map_err(Either::Left)?
+        {
+            ProposalValidity::Valid => self
+                .1
+                .validate_block_proposal(
+                    parent_block_hash,
+                    coinbase_txn_wit,
+                    template,
+                )
+                .await
+                .map_err(Either::Right),
+            invalid @ ProposalValidity::InvalidTx(_) => Ok(invalid),
+        }
     }
 
     type SuffixTxsError = Either<C0::SuffixTxsError, C1::SuffixTxsError>;
@@ -214,6 +282,20 @@ impl CusfBlockProducer for cusf_enforcer::DefaultEnforcer {
         Ok(template)
     }
 
+    type ValidateBlockProposalError = Infallible;
+
+    async fn validate_block_proposal<const COINBASE_TXN: bool>(
+        &self,
+        _parent_block_hash: &BlockHash,
+        _coinbase_txn_wit: typewit::const_marker::BoolWit<COINBASE_TXN>,
+        _template: &InitialBlockTemplate<COINBASE_TXN>,
+    ) -> Result<ProposalValidity, Self::ValidateBlockProposalError>
+    where
+        typewit::const_marker::Bool<COINBASE_TXN>: CoinbaseTxn,
+    {
+        Ok(ProposalValidity::Valid)
+    }
+
     type SuffixTxsError = Infallible;
 
     async fn block_template_suffix<const COINBASE_TXN: bool>(
@@ -260,6 +342,38 @@ where
                 .map_err(Either::Left),
             Self::Right(right) => right
                 .initial_block_template(
+                    parent_block_hash,
+                    coinbase_txn_wit,
+                    template,
+                )
+                .await
+                .map_err(Either::Right),
+        }
+    }
+
+    type ValidateBlockProposalError =
+        Either<C0::ValidateBlockProposalError, C1::ValidateBlockProposalError>;
+
+    async fn validate_block_proposal<const COINBASE_TXN: bool>(
+        &self,
+        parent_block_hash: &BlockHash,
+        coinbase_txn_wit: typewit::const_marker::BoolWit<COINBASE_TXN>,
+        template: &InitialBlockTemplate<COINBASE_TXN>,
+    ) -> Result<ProposalValidity, Self::ValidateBlockProposalError>
+    where
+        typewit::const_marker::Bool<COINBASE_TXN>: CoinbaseTxn,
+    {
+        match self {
+            Self::Left(left) => left
+                .validate_block_proposal(
+                    parent_block_hash,
+                    coinbase_txn_wit,
+                    template,
+                )
+                .await
+                .map_err(Either::Left),
+            Self::Right(right) => right
+                .validate_block_proposal(
                     parent_block_hash,
                     coinbase_txn_wit,
                     template,

--- a/lib/mempool/mod.rs
+++ b/lib/mempool/mod.rs
@@ -761,7 +761,7 @@ impl Mempool {
 
     /// Remove a tx from mempool, and all descendants.
     /// Returns the removed tx (if it was present) and any descendants.
-    fn remove_with_descendants(
+    pub(crate) fn remove_with_descendants(
         &mut self,
         txid: &Txid,
     ) -> Result<LinkedHashMap<Txid, Transaction>, MempoolRemoveError> {

--- a/lib/server.rs
+++ b/lib/server.rs
@@ -330,12 +330,18 @@ where
     FinalizeCoinbaseTx(#[from] FinalizeCoinbaseTxError),
     #[error(transparent)]
     InitialBlockTemplate(BP::InitialBlockTemplateError),
+    #[error(
+        "Invalid tx `{txid}` in block proposal cannot be excluded from the proposal"
+    )]
+    InvalidProposalTx { txid: Txid },
     #[error(transparent)]
     MempoolInsert(#[from] crate::mempool::MempoolInsertError),
     #[error(transparent)]
     MempoolRemove(#[from] crate::mempool::MempoolRemoveError),
     #[error(transparent)]
     SuffixTxs(BP::SuffixTxsError),
+    #[error(transparent)]
+    ValidateBlockProposal(BP::ValidateBlockProposalError),
 }
 
 // select block txs, and coinbase txouts if coinbasetxn is set
@@ -472,45 +478,85 @@ async fn block_txs<const COINBASE_TXN: bool, BP>(
         .sum();
     let initial_block_template_weight =
         coinbase_txouts_weight + prefix_txs_weight;
-    let mempool_txs = mempool.propose_txs(Some(
-        mempool::MAX_USABLE_BLOCK_WEIGHT - initial_block_template_weight,
-    ))?;
-    {
-        let proposed_txids: String = {
-            use std::fmt::Write;
-            // Above this number of txs, truncate txids to save space in logs
-            const SHOW_FULL_TXIDS_MAX_TXS: usize = 10;
-            let mut proposed_txids = "[".to_owned();
-            let n_txs = mempool_txs.len();
-            for (idx, tx) in mempool_txs.iter().enumerate() {
-                if idx < SHOW_FULL_TXIDS_MAX_TXS {
-                    write!(&mut proposed_txids, "{}", tx.txid).unwrap();
-                } else {
-                    let txid_bytes = tx.txid.as_byte_array();
-                    for byte in txid_bytes.iter().rev().take(4) {
-                        write!(&mut proposed_txids, "{byte:02x}").unwrap();
+    let weight_limit =
+        mempool::MAX_USABLE_BLOCK_WEIGHT - initial_block_template_weight;
+    // Propose txs, and validate the proposal with the block producer.
+    // A tx can be valid in isolation, yet invalid in the context of the
+    // specific proposal. Exclude any tx that the block producer identifies
+    // as invalid (along with its descendants), and propose again, so that
+    // one such tx cannot wedge block production.
+    let mempool_txs = loop {
+        let mempool_txs = mempool.propose_txs(Some(weight_limit))?;
+        {
+            let proposed_txids: String = {
+                use std::fmt::Write;
+                // Above this number of txs, truncate txids to save space in logs
+                const SHOW_FULL_TXIDS_MAX_TXS: usize = 10;
+                let mut proposed_txids = "[".to_owned();
+                let n_txs = mempool_txs.len();
+                for (idx, tx) in mempool_txs.iter().enumerate() {
+                    if idx < SHOW_FULL_TXIDS_MAX_TXS {
+                        write!(&mut proposed_txids, "{}", tx.txid).unwrap();
+                    } else {
+                        let txid_bytes = tx.txid.as_byte_array();
+                        for byte in txid_bytes.iter().rev().take(4) {
+                            write!(&mut proposed_txids, "{byte:02x}").unwrap();
+                        }
+                        write!(&mut proposed_txids, "...").unwrap();
+                        for byte in txid_bytes[..4].iter().rev() {
+                            write!(&mut proposed_txids, "{byte:02x}").unwrap();
+                        }
                     }
-                    write!(&mut proposed_txids, "...").unwrap();
-                    for byte in txid_bytes[..4].iter().rev() {
-                        write!(&mut proposed_txids, "{byte:02x}").unwrap();
+                    if idx + 1 < n_txs {
+                        write!(&mut proposed_txids, ", ").unwrap();
                     }
                 }
-                if idx + 1 < n_txs {
-                    write!(&mut proposed_txids, ", ").unwrap();
-                }
-            }
-            write!(&mut proposed_txids, "]").unwrap();
-            proposed_txids
+                write!(&mut proposed_txids, "]").unwrap();
+                proposed_txids
+            };
+            tracing::debug!(%proposed_txids, "Proposed txs for inclusion in block");
+        }
+        let candidate_template = {
+            let mut candidate = initial_block_template.clone();
+            candidate.prefix_txs.extend(mempool_txs.iter().map(|tx| {
+                let fee = tx.fee.unsigned_abs();
+                let tx = bitcoin::consensus::deserialize(&tx.data).unwrap();
+                (tx, fee)
+            }));
+            candidate
         };
-        tracing::debug!(%proposed_txids, "Proposed txs for inclusion in block");
-    }
-    initial_block_template
-        .prefix_txs
-        .extend(mempool_txs.iter().map(|tx| {
-            let fee = tx.fee.unsigned_abs();
-            let tx = bitcoin::consensus::deserialize(&tx.data).unwrap();
-            (tx, fee)
-        }));
+        tracing::debug!("Validating block proposal");
+        match block_producer
+            .validate_block_proposal(
+                parent_block_hash,
+                typewit::MakeTypeWitness::MAKE,
+                &candidate_template,
+            )
+            .await
+            .map_err(BuildBlockError::ValidateBlockProposal)?
+        {
+            cusf_block_producer::ProposalValidity::Valid => {
+                initial_block_template = candidate_template;
+                break mempool_txs;
+            }
+            cusf_block_producer::ProposalValidity::InvalidTx(txid) => {
+                // The block producer's own prefix txs cannot be excluded
+                let excluded = if prefix_txids.contains(&txid) {
+                    Default::default()
+                } else {
+                    mempool.remove_with_descendants(&txid)?
+                };
+                if excluded.is_empty() {
+                    return Err(BuildBlockError::InvalidProposalTx { txid });
+                }
+                tracing::warn!(
+                    %txid,
+                    n_excluded = excluded.len(),
+                    "Excluding invalid tx (and descendants) from block proposal"
+                );
+            }
+        }
+    };
     tracing::debug!("Adding block template suffix");
     let template_suffix = block_producer
         .block_template_suffix(


### PR DESCRIPTION
A tx can be valid in isolation, yet invalid in the context of a block proposal. Its validity can depend on state that an earlier tx in the proposal modifies.