### PR TITLE
Mempool sync: fetch parent block before disconnecting through sync tip

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,7 @@ build *args='':
 
 # Run linter
 clippy:
-    cargo clippy --all-targets -- --deny warnings
+    cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged -- --deny warnings
 
 # Format code
 fmt:

--- a/integration_tests/lib.rs
+++ b/integration_tests/lib.rs
@@ -2,6 +2,7 @@ pub mod mock_enforcer;
 pub mod setup;
 pub mod test_accept_tx_paths;
 pub mod test_block_connect_smoke;
+pub mod test_disconnect_through_sync_tip;
 pub mod test_double_insert_after_reorg;
 pub mod test_enforcer_rejection_during_reorg;
 pub mod test_rbf_removed_for_absent_tx;

--- a/integration_tests/main.rs
+++ b/integration_tests/main.rs
@@ -4,8 +4,9 @@ use clap::Parser;
 use cusf_enforcer_mempool_integration_tests::{
     setup::{Directories, TestSetup},
     test_accept_tx_paths, test_block_connect_smoke,
-    test_double_insert_after_reorg, test_enforcer_rejection_during_reorg,
-    test_rbf_removed_for_absent_tx, test_reorg_re_inserts_tx,
+    test_disconnect_through_sync_tip, test_double_insert_after_reorg,
+    test_enforcer_rejection_during_reorg, test_rbf_removed_for_absent_tx,
+    test_reorg_re_inserts_tx,
     util::{BinPaths, TestFailure, TestFailureCollector},
 };
 use libtest_mimic::{Arguments, Trial};
@@ -184,6 +185,13 @@ fn run() -> anyhow::Result<std::process::ExitCode> {
         ("double_insert_after_reorg", |bp, dirs| {
             Box::pin(
                 test_double_insert_after_reorg::test_double_insert_after_reorg(
+                    bp, dirs,
+                ),
+            )
+        }),
+        ("disconnect_through_sync_tip", |bp, dirs| {
+            Box::pin(
+                test_disconnect_through_sync_tip::test_disconnect_through_sync_tip(
                     bp, dirs,
                 ),
             )

--- a/integration_tests/test_disconnect_through_sync_tip.rs
+++ b/integration_tests/test_disconnect_through_sync_tip.rs
@@ -1,0 +1,63 @@
+//! A reorg that disconnects the initial-sync tip must leave `Mempool::tip()`
+//! usable. `init_sync_mempool` fetches only the sync-time tip into
+//! `chain.blocks` — never its parent — so when `handle_disconnected_block`
+//! rolls `chain.tip` back to the parent hash, `Mempool::tip()`
+//! (`chain.blocks[&chain.tip]`) panics on the missing key until the next
+//! block connects, killing e.g. `getblocktemplate` callers.
+
+use std::time::Duration;
+
+use anyhow::anyhow;
+use bitcoin::BlockHash;
+use bitcoin_jsonrpsee::{
+    MainClient as _,
+    jsonrpsee::{core::client::ClientT, rpc_params},
+};
+
+use crate::{
+    setup::{Directories, RegtestNode, TestSetup},
+    util::{BinPaths, RpcClient},
+};
+
+async fn get_block_parent(
+    rpc: &RpcClient,
+    hash: BlockHash,
+) -> anyhow::Result<BlockHash> {
+    let res: serde_json::Value = rpc
+        .request("getblockheader", rpc_params![hash.to_string()])
+        .await?;
+    let prev = res["previousblockhash"].as_str().ok_or_else(|| {
+        anyhow!("getblockheader missing `previousblockhash`: {res:?}")
+    })?;
+    Ok(prev.parse()?)
+}
+
+pub async fn test_disconnect_through_sync_tip(
+    bin_paths: BinPaths,
+    directories: Directories,
+) -> anyhow::Result<()> {
+    let node = RegtestNode::new(&bin_paths, directories).await?;
+
+    // Let bitcoind finish flushing ZMQ connect events from the priming mine
+    // before init-sync subscribes. A stale connect replay fetches the sync
+    // tip's ancestors, masking the missing-parent case
+    // this test exercises.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let setup = TestSetup::start(node).await?;
+    let sync_tip = setup.node.rpc_client.getbestblockhash().await?;
+    let parent = get_block_parent(&setup.node.rpc_client, sync_tip).await?;
+
+    setup.node.rpc_client.invalidate_block(sync_tip).await?;
+
+    setup
+        .wait_for_local_tip(parent, Duration::from_secs(15))
+        .await?;
+
+    anyhow::ensure!(
+        setup.enforcer.disconnect_block_calls() == 1,
+        "expected exactly one disconnect_block call, got {}",
+        setup.enforcer.disconnect_block_calls()
+    );
+    Ok(())
+}

--- a/lib/mempool/sync/task.rs
+++ b/lib/mempool/sync/task.rs
@@ -146,6 +146,7 @@ pub struct SyncState {
 
 /// Sync state, mutably borrowed while applying an action from the queue
 struct SyncStateBorrowedMut<'a> {
+    blocks_needed: &'a mut LinkedHashSet<BlockHash>,
     /// Txs rejected by the CUSF enforcer
     rejected_txs: &'a mut HashSet<Txid>,
     request_queue: &'a RequestQueue,
@@ -268,25 +269,46 @@ where
     Ok(())
 }
 
+/// Returns `false` without applying the disconnect if the parent block must
+/// first be fetched into `chain.blocks`. The caller should retry once the
+/// parent block response has been handled.
 async fn handle_disconnected_block<Enforcer, BorrowedEnforcer>(
     inner: &mut MempoolSyncInner<Enforcer>,
+    blocks_needed: &mut LinkedHashSet<BlockHash>,
+    request_queue: &RequestQueue,
     block: &bitcoin_jsonrpsee::client::Block<true>,
-) -> Result<(), SyncTaskError<BorrowedEnforcer>>
+) -> Result<bool, SyncTaskError<BorrowedEnforcer>>
 where
     Enforcer: BorrowMut<BorrowedEnforcer>,
     BorrowedEnforcer: CusfEnforcer,
 {
     let prev_blockhash =
         block.previousblockhash.unwrap_or_else(BlockHash::all_zeros);
-    if inner.unfiltered_mempool.tip == block.hash {
-        inner.unfiltered_mempool.tip = prev_blockhash;
-    } else {
+    if inner.unfiltered_mempool.tip != block.hash {
         return Err(SyncTaskError::DisconnectTipMismatch {
             disconnected_tip: block.hash,
             unfiltered_mempool_tip: inner.unfiltered_mempool.tip,
         });
-    };
+    }
     if inner.mempool.chain.tip == block.hash {
+        // Rolling the tip back requires the parent block to be present in
+        // `chain.blocks` because `Mempool::tip` indexes into it. The parent is
+        // absent if it predates the initial sync, which fetches only the
+        // sync-time tip itself.
+        if block.previousblockhash.is_some()
+            && !inner.mempool.chain.blocks.contains_key(&prev_blockhash)
+        {
+            if !blocks_needed.contains(&prev_blockhash) {
+                tracing::debug!(
+                    block_hash = %block.hash,
+                    %prev_blockhash,
+                    "Requesting parent block before disconnect"
+                );
+                blocks_needed.replace(prev_blockhash);
+                request_queue.push_front(RequestItem::Block(prev_blockhash));
+            }
+            return Ok(false);
+        }
         let DisconnectBlockAction { remove_mempool_txs } = inner
             .enforcer
             .borrow_mut()
@@ -298,7 +320,8 @@ where
         }
         inner.mempool.chain.tip = prev_blockhash;
     }
-    Ok(())
+    inner.unfiltered_mempool.tip = prev_blockhash;
+    Ok(true)
 }
 
 fn handle_block_hash_msg<Enforcer>(
@@ -465,6 +488,7 @@ where
         ))) if *block_hash == resp_block.hash => {
             {
                 let sync_state = SyncStateBorrowedMut {
+                    blocks_needed: &mut sync_state.blocks_needed,
                     rejected_txs: &mut sync_state.rejected_txs,
                     request_queue: &sync_state.request_queue,
                     tx_cache: &mut sync_state.tx_cache,
@@ -484,8 +508,16 @@ where
         ))) if *block_hash == resp_block.hash
             && inner.mempool.chain.tip == resp_block.hash =>
         {
-            let () = handle_disconnected_block(inner, &resp_block).await?;
-            sync_state.action_queue.pop_front();
+            if handle_disconnected_block(
+                inner,
+                &mut sync_state.blocks_needed,
+                &sync_state.request_queue,
+                &resp_block,
+            )
+            .await?
+            {
+                sync_state.action_queue.pop_front();
+            }
         }
         Some(_) | None => (),
     }
@@ -750,10 +782,14 @@ where
             else {
                 return Ok(ApplySyncActionResult::Pending);
             };
-            let () = handle_disconnected_block(inner, &block).await?;
-            Ok(ApplySyncActionResult::Success {
-                push_txs_action_queue_front: Vec::new(),
-            })
+            let applied = handle_disconnected_block(
+                inner,
+                sync_state.blocks_needed,
+                sync_state.request_queue,
+                &block,
+            )
+            .await?;
+            Ok(ApplySyncActionResult::from(applied))
         }
         SequenceMessage::TxHash(TxHashMessage {
             txid,
@@ -812,6 +848,7 @@ where
     let res = match next_sync_action.action {
         SyncAction::InsertTx(txid) => {
             let sync_state = SyncStateBorrowedMut {
+                blocks_needed: &mut sync_state.blocks_needed,
                 rejected_txs: &mut sync_state.rejected_txs,
                 request_queue: &sync_state.request_queue,
                 tx_cache: &mut sync_state.tx_cache,
@@ -822,6 +859,7 @@ where
         }
         SyncAction::SequenceMessage(seq_msg) => {
             let sync_state = SyncStateBorrowedMut {
+                blocks_needed: &mut sync_state.blocks_needed,
                 rejected_txs: &mut sync_state.rejected_txs,
                 request_queue: &sync_state.request_queue,
                 tx_cache: &mut sync_state.tx_cache,


### PR DESCRIPTION
Prior to this commit, a reorg that disconnects back through the sync tip would panic. Demonstrated by the added integration test.